### PR TITLE
Don't register QueuedJobService shutdown when running tests

### DIFF
--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -64,7 +64,7 @@ class QueuedJobService {
 	 */
 	public function __construct() {
 		// bind a shutdown function to process all 'immediate' queued jobs if needed, but only in CLI mode
-		if (self::$use_shutdown_function && Director::is_cli()) {
+		if (self::$use_shutdown_function && Director::is_cli() && !SapphireTest::is_running_test()) {
 			register_shutdown_function(array($this, 'onShutdown'));
 		}
 	}


### PR DESCRIPTION
Causes a big SQL failure at the end of a dev/tests run, because
there's no database available to run the shutdown database query.

This won't affect unit tests faking shutdown, as they call `onShutdown`
explicitly, instead of through `register_shutdown_function`.
