### PR TITLE
errorwriter errors

### DIFF
--- a/code/QJUtils.php
+++ b/code/QJUtils.php
@@ -84,7 +84,7 @@ class QJUtils {
 			'errstr' => $message,
 			'errfile' => dirname(__FILE__),
 			'errline' => '',
-			'errcontext' => ''
+			'errcontext' => array('')
 		);
 
 		SS_Log::log($message, $level);

--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -277,7 +277,7 @@ class QueuedJobService {
 					'errstr' => 'Broken jobs were found in the job queue',
 					'errfile' => __FILE__,
 					'errline' => __LINE__,
-					'errcontext' => ''
+					'errcontext' => array('')
 				), SS_Log::ERR);
 			}
 		}
@@ -422,7 +422,7 @@ class QueuedJobService {
 						'errstr' => 'Job descriptor ' . $jobId . ' could not be found',
 						'errfile' => __FILE__,
 						'errline' => __LINE__,
-						'errcontext' => ''
+						'errcontext' => array('')
 					), SS_Log::ERR);
 					break;
 				}
@@ -472,7 +472,7 @@ class QueuedJobService {
 						'errstr' => 'Job descriptor has been set to null',
 						'errfile' => __FILE__,
 						'errline' => __LINE__,
-						'errcontext' => ''
+						'errcontext' => array('')
 					), SS_Log::WARN);
 					$broken = true;
 				}


### PR DESCRIPTION
errcontext need to be an array, otherwise the errorwriters throw an error.