### PR TITLE
Fix deprecation errors on static vars

### DIFF
--- a/tests/ScheduledExecutionTest.php
+++ b/tests/ScheduledExecutionTest.php
@@ -112,12 +112,12 @@ class ScheduledExecutionTest extends SapphireTest {
 
 
 class TestScheduledDataObject extends DataObject implements TestOnly {
-	public static $db = array(
+	private static $db = array(
 		'Title' => 'Varchar',
 		'Message' => 'Varchar',
 	);
 	
-	public static $extensions = array(
+	private static $extensions = array(
 		'ScheduledExecutionExtension'
 	);
 	


### PR DESCRIPTION
Fixes these warnings: 
Deprecated: Config static TestScheduledDataObject::$extensions must be marked as private
Deprecated: Config static TestScheduledDataObject::$db must be marked as private