### PR TITLE
API Better restarting of stalled jobs (when StepsProcessed == 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,28 @@ _must_ detect whether they're present or not before using them. See [this issue]
 and [this wiki page](https://github.com/silverstripe-australia/silverstripe-queuedjobs/wiki/Defining-queued-jobs) for 
 more information
 
+Ensure that notifications are configured so that you can get updates or stalled or broken jobs. You can 
+set the notification email address in your config as below:
+
+
+	:::yaml
+	Email:
+	  queued_job_admin_email: support@mycompany.com
+
+## Memory limit configuration
+
+By default this task will run until either 128mb or the limit specified by php_ini('memory_limit') is reached.
+
+You can adjust this with the below config change
+
+
+	:::yaml
+	# Force memory limit to 256 megabytes
+	QueuedJobsService:
+	  # Accepts b, k, m, or b suffixes
+	  memory_limit: 256m
+
+
 ## Indexes
 
 ALTER TABLE `QueuedJobDescriptor` ADD INDEX ( `JobStatus` , `JobType` ) 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ set the notification email address in your config as below:
 	Email:
 	  queued_job_admin_email: support@mycompany.com
 
-## Memory limit configuration
+## Performance configuration
 
 By default this task will run until either 128mb or the limit specified by php_ini('memory_limit') is reached.
 
@@ -132,6 +132,16 @@ You can adjust this with the below config change
 	QueuedJobsService:
 	  # Accepts b, k, m, or b suffixes
 	  memory_limit: 256m
+
+
+You can also enforce a time limit for each queue, after which the task will attempt a restart to release all
+resources. By default this is disabled, so you must specify this in your project as below:
+
+
+	:::yaml
+	# Force limit to 10 minutes
+	QueuedJobsService:
+	  time_limit: 600
 
 
 ## Indexes

--- a/code/tasks/ProcessJobQueueTask.php
+++ b/code/tasks/ProcessJobQueueTask.php
@@ -66,6 +66,9 @@ class ProcessJobQueueTask extends BuildTask {
 			}
 			return;
 		}
+
+		// Cleanup or restart jobs before processing
+		$service->checkJobHealth();
 		
 		/* @var $service QueuedJobService */
 		$nextJob = null;
@@ -77,8 +80,6 @@ class ProcessJobQueueTask extends BuildTask {
 		} else {
 			$nextJob = $service->getNextPendingJob($queue);
 		}
-
-		$service->checkJobHealth();
 
 		if ($nextJob) {
 			$this->writeLogLine("$datestamp Running $nextJob->JobTitle and others from $queue.");

--- a/tests/QueuedJobsTest.php
+++ b/tests/QueuedJobsTest.php
@@ -5,10 +5,31 @@
  *
  * @author Marcus Nyeholt <marcus@silverstripe.com.au>
  */
-class QueuedJobsTest extends SapphireTest
-{
+class QueuedJobsTest extends SapphireTest {
+
+	public function setUp() {
+		parent::setUp();
+
+		Config::nest();
+		// Two restarts are allowed per job
+		Config::inst()->update('QueuedJobService', 'stall_threshold', 2);
+	}
+
+	public function tearDown() {
+		Config::unnest();
+		parent::tearDown();
+	}
+
+
+	/**
+	 * @return QueuedJobService
+	 */
+	protected function getService() {
+		return singleton("TestQJService");
+	}
+
 	public function testQueueJob() {
-		$svc = singleton("QueuedJobService");
+		$svc = $this->getService();
 
 		// lets create a new job and add it tio the queue
 		$job = new TestQueuedJob();
@@ -32,7 +53,7 @@ class QueuedJobsTest extends SapphireTest
 	}
 
 	public function testJobRunAs() {
-		$svc = singleton("QueuedJobService");
+		$svc = $this->getService();
 		$list = $svc->getJobList();
 		foreach ($list as $job) {
 			$job->delete();
@@ -52,7 +73,7 @@ class QueuedJobsTest extends SapphireTest
 	}
 
 	public function testQueueSignature() {
-		$svc = singleton("QueuedJobService");
+		$svc = $this->getService();
 
 		// lets create a new job and add it tio the queue
 		$job = new TestQueuedJob();
@@ -111,7 +132,7 @@ class QueuedJobsTest extends SapphireTest
 
 	public function testInitialiseJob() {
 		// okay, lets test it out on the actual service
-		$svc = singleton("TestQJService");
+		$svc = $this->getService();
 		// lets create a new job and add it to the queue
 		$job = new TestQueuedJob();
 		$id = $svc->queueJob($job);
@@ -128,7 +149,7 @@ class QueuedJobsTest extends SapphireTest
 
 	public function testStartJob() {
 		// okay, lets test it out on the actual service
-		$svc = singleton("QueuedJobService");
+		$svc = $this->getService();
 		// lets create a new job and add it to the queue
 
 		$this->logInWithPermission('DUMMYUSER');
@@ -149,7 +170,7 @@ class QueuedJobsTest extends SapphireTest
 
 	public function testImmediateQueuedJob() {
 		// okay, lets test it out on the actual service
-		$svc = singleton("QueuedJobService");
+		$svc = $this->getService();
 		// lets create a new job and add it to the queue
 
 		$job = new TestQueuedJob(QueuedJob::IMMEDIATE);
@@ -172,7 +193,7 @@ class QueuedJobsTest extends SapphireTest
 	}
 
 	public function testNextJob() {
-		$svc = singleton("TestQJService");
+		$svc = $this->getService();
 		$list = $svc->getJobList();
 
 		foreach ($list as $job) {
@@ -211,49 +232,122 @@ class QueuedJobsTest extends SapphireTest
 		
 		$this->assertFalse($next);
 	}
-	
-	public function testJobHealthCheck() {
-		$svc = singleton("QueuedJobService");
-		// lets create a new job and add it to the queue
 
+	/**
+	 * Verify that broken jobs are correctly verified for health and restarted as necessary
+	 *
+	 * Order of checkJobHealth() and getNextPendingJob() is important
+	 *
+	 * Execution of this job is broken into several "loops", each of which represents one invocation
+	 * of ProcessJobQueueTask
+	 */
+	public function testJobHealthCheck() {
+		// Create a job and add it to the queue
+		$svc = $this->getService();
 		$job = new TestQueuedJob(QueuedJob::IMMEDIATE);
 		$job->firstJob = true;
 		$id = $svc->queueJob($job);
-		
 		$descriptor = QueuedJobDescriptor::get()->byID($id);
-		
-		$descriptor->JobStatus = 'Running';
-		$descriptor->StepsProcessed = 1;
-//		$descriptor->LastProcessedCount = 1;
 
-		$descriptor->write();
-		
+		// Verify initial state is new and LastProcessedCount is not marked yet
+		$this->assertEquals(QueuedJob::STATUS_NEW, $descriptor->JobStatus);
+		$this->assertEquals(0, $descriptor->StepsProcessed);
+		$this->assertEquals(-1, $descriptor->LastProcessedCount);
+		$this->assertEquals(0, $descriptor->ResumeCounts);
+
+		// Loop 1 - Pick up new job and attempt to run it
+		// Job health should not attempt to cleanup unstarted jobs
 		$svc->checkJobHealth();
-		
+		$nextJob = $svc->getNextPendingJob(QueuedJob::IMMEDIATE);
+
+		// Ensure that this is the next job ready to go
 		$descriptor = QueuedJobDescriptor::get()->byID($id);
-		$this->assertEquals(1, $descriptor->LastProcessedCount);
-		
-		$svc->checkJobHealth();
-		
-		$descriptor = QueuedJobDescriptor::get()->byID($id);
-		$this->assertEquals(QueuedJob::STATUS_WAIT, $descriptor->JobStatus);
-		
-		// the same for init broken jobs
-		$descriptor->JobTitle = 'Test job broken in init';
+		$this->assertEquals($nextJob->ID, $descriptor->ID);
+		$this->assertEquals(QueuedJob::STATUS_NEW, $descriptor->JobStatus);
+		$this->assertEquals(0, $descriptor->StepsProcessed);
+		$this->assertEquals(-1, $descriptor->LastProcessedCount);
+		$this->assertEquals(0, $descriptor->ResumeCounts);
+
+		// Run 1 - Start the job (no work is done)
 		$descriptor->JobStatus = QueuedJob::STATUS_INIT;
-		$descriptor->LastProcessedCount = 0;
 		$descriptor->write();
-		
+
+		// Assume that something bad happens at this point, the process dies during execution, and
+		// the task is re-initiated somewhere down the track
+
+		// Loop 2 - Detect broken job, and mark it for future checking.
 		$svc->checkJobHealth();
-		
+		$nextJob = $svc->getNextPendingJob(QueuedJob::IMMEDIATE);
+
+		// Note that we don't immediately try to restart it until StepsProcessed = LastProcessedCount
 		$descriptor = QueuedJobDescriptor::get()->byID($id);
-		$this->assertEquals(1, $descriptor->LastProcessedCount);
-		
+		$this->assertFalse($nextJob); // Don't run it this round please!
+		$this->assertEquals(QueuedJob::STATUS_INIT, $descriptor->JobStatus);
+		$this->assertEquals(0, $descriptor->StepsProcessed);
+		$this->assertEquals(0, $descriptor->LastProcessedCount);
+		$this->assertEquals(0, $descriptor->ResumeCounts);
+
+		// Loop 3 - We've previously marked this job as broken, so restart it this round
+		// If no more work has been done on the job at this point, assume that we are able to
+		// restart it
 		$svc->checkJobHealth();
-		
+		$nextJob = $svc->getNextPendingJob(QueuedJob::IMMEDIATE);
+
+		// This job is resumed and exeuction is attempted this round
 		$descriptor = QueuedJobDescriptor::get()->byID($id);
+		$this->assertEquals($nextJob->ID, $descriptor->ID);
 		$this->assertEquals(QueuedJob::STATUS_WAIT, $descriptor->JobStatus);
-		
+		$this->assertEquals(0, $descriptor->StepsProcessed);
+		$this->assertEquals(0, $descriptor->LastProcessedCount);
+		$this->assertEquals(1, $descriptor->ResumeCounts);
+
+		// Run 2 - First restart (work is done)
+		$descriptor->JobStatus = QueuedJob::STATUS_RUN;
+		$descriptor->StepsProcessed++; // Essentially delays the next restart by 1 loop
+		$descriptor->write();
+
+		// Once again, at this point, assume the job fails and crashes
+
+		// Loop 4 - Assuming a job has LastProcessedCount < StepsProcessed we are in the same
+		// situation as step 2.
+		// Because the last time the loop ran, StepsProcessed was incremented,
+		// this indicates that it's likely that another task could be working on this job, so
+		// don't run this.
+		$svc->checkJobHealth();
+		$nextJob = $svc->getNextPendingJob(QueuedJob::IMMEDIATE);
+
+		$descriptor = QueuedJobDescriptor::get()->byID($id);
+		$this->assertFalse($nextJob); // Don't run jobs we aren't sure should be restarted
+		$this->assertEquals(QueuedJob::STATUS_RUN, $descriptor->JobStatus);
+		$this->assertEquals(1, $descriptor->StepsProcessed);
+		$this->assertEquals(1, $descriptor->LastProcessedCount);
+		$this->assertEquals(1, $descriptor->ResumeCounts);
+
+		// Loop 5 - Job is again found to not have been restarted since last iteration, so perform second
+		// restart. The job should be attempted to run this loop
+		$svc->checkJobHealth();
+		$nextJob = $svc->getNextPendingJob(QueuedJob::IMMEDIATE);
+
+		// This job is resumed and exeuction is attempted this round
+		$descriptor = QueuedJobDescriptor::get()->byID($id);
+		$this->assertEquals($nextJob->ID, $descriptor->ID);
+		$this->assertEquals(QueuedJob::STATUS_WAIT, $descriptor->JobStatus);
+		$this->assertEquals(1, $descriptor->StepsProcessed);
+		$this->assertEquals(1, $descriptor->LastProcessedCount);
+		$this->assertEquals(2, $descriptor->ResumeCounts);
+
+		// Run 3 - Second and last restart (no work is done)
+		$descriptor->JobStatus = QueuedJob::STATUS_RUN;
+		$descriptor->write();
+
+		// Loop 6 - As no progress has been made since loop 3, we can mark this as dead
+		$svc->checkJobHealth();
+		$nextJob = $svc->getNextPendingJob(QueuedJob::IMMEDIATE);
+
+		// Since no StepsProcessed has been done, don't wait another loop to mark this as dead
+		$descriptor = QueuedJobDescriptor::get()->byID($id);
+		$this->assertEquals(QueuedJob::STATUS_PAUSED, $descriptor->JobStatus);
+		$this->assertEmpty($nextJob);
 	}
 }
 


### PR DESCRIPTION
BUG Better memory detection
BUG Correct usage of configurable options in QueuedJobService
BUG Corrected "ResumeCount" to "ResumeCounts"

Another potential solution to https://github.com/silverstripe-australia/silverstripe-queuedjobs/issues/41

@nyeholt would you be able to please review my logic? I've written up a complete unit test covering job restart and I believe that my logic is correct, but it deserves some critique.

I have replaced the requirement that StepsProcessed must be > 0 in order to be restartable, and instead changed LastProcessedCount to default to -1 (and is set to 0 during checkJobHealth on jobs that are suspected of requiring restart). This means that although jobs won't restart immediately, if no work is done on them they will eventually restart.