### PR TITLE
Order jobs by latest created

### DIFF
--- a/code/controllers/QueuedJobsAdmin.php
+++ b/code/controllers/QueuedJobsAdmin.php
@@ -30,7 +30,7 @@ class QueuedJobsAdmin extends ModelAdmin {
 		$filter = $this->jobQueue->getJobListFilter(null, 300);
 
 		$list = DataList::create('QueuedJobDescriptor');
-		$list = $list->where($filter);
+		$list = $list->where($filter)->sort('Created', 'DESC');
 
 		$gridFieldConfig = GridFieldConfig_RecordEditor::create()
 			->addComponent(new GridFieldQueuedJobExecute('execute'))


### PR DESCRIPTION
When in the CMS as a user I usually care about more recent log messages than older ones. This is especially the case when reloading the page to watch for updates from the task. If it's on the last page, GridField currently doesn't remember the page.