### PR TITLE
DOC document job health check workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,15 @@ set the notification email address in your config as below:
 	Email:
 	  queued_job_admin_email: support@mycompany.com
 
+**Long running jobs are running multiple times!**
+
+A long running job _may_ fool the system into thinking it has gone away (ie the job health check fails because 
+`currentStep` hasn't been incremented). To avoid this scenario, you can set `$this->currentStep = -1` in your job's
+constructor, to prevent any health checks detecting the job. 
+
 ## Performance configuration
 
-By default this task will run until either 128mb or the limit specified by php_ini('memory_limit') is reached.
+By default this task will run until either 128mb or the limit specified by php\_ini('memory\_limit') is reached.
 
 You can adjust this with the below config change
 

--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -366,7 +366,7 @@ class QueuedJobService {
 		$this->copyDescriptorToJob($jobDescriptor, $job);
 
 		// see if it needs 'setup' or 'restart' called
-		if (!$jobDescriptor->StepsProcessed) {
+		if ($jobDescriptor->StepsProcessed <= 0) {
 			$job->setup();
 		} else {
 			$job->prepareForRestart();


### PR DESCRIPTION
Fix for #46 - documented a workaround for the jobqueue health check mistakenly marking a job
as being paused (ie set currentStep = -1).

Tweaked some code in QueuedJobDescriptor to ensure that only jobs with a
StepsProcessed count > 0 are considered as needing a 'restart' instead of a
'setup'