### PR TITLE
Readded function to list current jobs in ProcessJobQueueTask

### DIFF
--- a/code/tasks/ProcessJobQueueTask.php
+++ b/code/tasks/ProcessJobQueueTask.php
@@ -21,14 +21,15 @@ class ProcessJobQueueTask extends BuildTask {
 	 * @param SS_HTTPRequest $request
 	 */
 	public function run($request) {
+		$service = $this->getService();
+
 		if($request->getVar('list')) {
 			// List helper
-			$this->listJobs();
+			$service->queueRunner->listJobs();
 			return;
 		}
 
 		// Check if there is a job to run
-		$service = $this->getService();
 		if(($job = $request->getVar('job')) && strpos($job, '-')) {
 			// Run from a isngle job
 			$parts = explode('-', $job);

--- a/code/tasks/engines/BaseRunner.php
+++ b/code/tasks/engines/BaseRunner.php
@@ -53,4 +53,16 @@ class BaseRunner {
 			$this->writeLogLine('Running ' . $descriptor->JobTitle . ' and others from ' . $queue . '.');
 		}
 	}
+
+	/**
+	 * Logs the number of current jobs per queue
+	 */
+	public function listJobs() {
+		$service = $this->getService();
+		for($i = 1; $i <= 3; $i++) {
+			$jobs = $service->getJobList($i);
+			$num = $jobs ? $jobs->Count() : 0;
+			$this->writeLogLine('Found ' . $num . ' jobs for mode ' . $i . '.');
+		}
+	}
 }


### PR DESCRIPTION
ProcessJobQueueTask has an option to list current jobs but was missing the actual code. It seems to have been refactored away accidentally (#80). This fix restores the indented functionality.