### PR TITLE
Typo in QueuedJobService public property queueRunner

### DIFF
--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -82,7 +82,7 @@ class QueuedJobService {
 	 *
 	 * @var TaskRunnerEngine
 	 */
-	public $queuedRunner;
+	public $queueRunner;
 
 	/**
 	 * Register our shutdown handler


### PR DESCRIPTION
Little typo in the public $queueRunner property.