### PR TITLE
Remove CMS as composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
 	"require":
 	{
 		"silverstripe/framework": "~3.1",
-		"silverstripe/cms": "~3.1",
 		"silverstripe/multivaluefield": "~2.0",
 		"asyncphp/doorman": "~1.2"
 	},


### PR DESCRIPTION
After some local testing, it seems that silverstripe-cms doesn't really need to be a requirement for this project.