### PR TITLE
Fix reference to queued job admin email

### DIFF
--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -97,8 +97,8 @@ class QueuedJobService {
 			}
 
 		}
-		if (Config::inst()->get('Email', 'queued_jobs_admin_email') == '') {
-			Config::inst()->update('Email', 'queued_jobs_admin_email', Config::inst()->get('Email', 'admin_email'));
+		if (Config::inst()->get('Email', 'queued_job_admin_email') == '') {
+			Config::inst()->update('Email', 'queued_job_admin_email', Config::inst()->get('Email', 'admin_email'));
 		}
 	}
 


### PR DESCRIPTION
The documentation suggests that the correct config variable for error emails is queued_job_admin_email, however, the code in the constructor of the QueuedJobService is set to queued_jobs_admin_email/