### PR TITLE
BUG Remove invalid backtraces from errcontext

### DIFF
--- a/code/QJUtils.php
+++ b/code/QJUtils.php
@@ -90,7 +90,7 @@ class QJUtils {
 			'errstr' => $message,
 			'errfile' => dirname(__FILE__),
 			'errline' => '',
-			'errcontext' => array('')
+			'errcontext' => array()
 		);
 
 		SS_Log::log($message, $level);

--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -306,7 +306,7 @@ class QueuedJobService {
 				'errstr' => 'Broken jobs were found in the job queue',
 				'errfile' => __FILE__,
 				'errline' => __LINE__,
-				'errcontext' => array('')
+				'errcontext' => array()
 			), SS_Log::ERR);
 		}
 	}
@@ -521,7 +521,7 @@ class QueuedJobService {
 							'errstr' => 'Job descriptor ' . $jobId . ' could not be found',
 							'errfile' => __FILE__,
 							'errline' => __LINE__,
-							'errcontext' => array('')
+							'errcontext' => array()
 						), SS_Log::ERR);
 						break;
 					}
@@ -584,7 +584,7 @@ class QueuedJobService {
 							'errstr' => 'Job descriptor has been set to null',
 							'errfile' => __FILE__,
 							'errline' => __LINE__,
-							'errcontext' => array('')
+							'errcontext' => array()
 						), SS_Log::WARN);
 						$broken = true;
 					}


### PR DESCRIPTION
Fixes https://github.com/silverstripe-labs/silverstripe-fulltextsearch/issues/111

This causes errors because SS_Backtrace cannot parse these arrays as being valid backtraces.