### PR TITLE
Add daily CleanupJob to remove stale DB entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ developers set these processes to be executed in the future.
 The module comes with
 
 * A section in the CMS for viewing a list of currently running jobs or scheduled jobs.
-* An abstract skeleton class for defining your own jobs
+* An abstract skeleton class for defining your own jobs.
 * A task that is executed as a cronjob for collecting and executing jobs.
+* A pre-configured job to cleanup the QueuedJobDescriptor database table.
 
 ## Quick Usage Overview
 
@@ -120,6 +121,36 @@ inotifywait and then call the ProcessJobQueueTask when a new job is ready to run
 Note - if you do NOT have this running, make sure to set `QueuedJobService::$use_shutdown_function = true;`
 so that immediate mode jobs don't stall. By setting this to true, immediate jobs will be executed after
 the request finishes as the php script ends. 
+
+## Configuring the CleanupJob
+
+By default the CleanupJob is disabled. To enable it, set the following in your YML:
+
+```yaml
+CleanupJob:
+  is_enabled: true
+```
+This will ensure that the CleanupJob is run once a day.
+
+You can configure this job to clean up based on the number of jobs, or the age of the jobs. This is
+configured with the `cleanup_method` setting - current valid values are "age" (default)  and "number".
+Each of these methods will have a value associated with it - this is an integer, set with `cleanup_value`.
+For "age", this will be converted into days; for "number", it is the minimum number of records to keep, sorted by LastEdited.
+The default value is 30, as we are expecting days.
+
+You can also determine which JobStatuses are allowed to be cleaned up. The default setting is to clean up "Broken" and "Complete" jobs. All other statuses can be configured with `cleanup_statuses`.
+
+The default configuration looks like this:
+
+```yaml
+CleanupJob:
+  is_enabled: false
+  cleanup_method: "age"
+  cleanup_value: 30
+  cleanup_statuses:
+    - Broken
+	- Complete
+``` 
 
 
 ## Troubleshooting

--- a/code/jobs/CleanupJob.php
+++ b/code/jobs/CleanupJob.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * An queued job to clean out the QueuedJobDescriptor Table
+ * which often gets too full
+ *
+ * @author Andrew Aitken-Fincham <andrew@silverstripe.com.au>
+ */
+class CleanupJob extends AbstractQueuedJob implements QueuedJob {
+
+	/**
+	 * How we will determine "stale"
+	 * Possible values: age, number
+	 * @config
+	 * @var string
+	 */
+	private static $cleanup_method = "age";
+
+	/**
+	 * Value associated with cleanupMethod
+	 * age => days, number => integer
+	 * @config
+	 * @var integer
+	 */
+	private static $cleanup_value = 30;
+
+	/**
+	 * Which JobStatus values are OK to be deleted
+	 * @config
+	 * @var array
+	 */
+	private static $cleanup_statuses = array(
+		"Complete",
+		"Broken",
+		// "Initialising",
+		// "Running",
+		// "New",
+		// "Paused",
+		// "Cancelled",
+		// "Waiting",
+	);
+
+	/**
+	 * Check whether is enabled or not for BC
+	 * @config
+	 * @var boolean
+	 */
+	private static $is_enabled = false;
+
+	/**
+	 * Required because we aren't extending object
+	 * @return Config_ForClass
+	 */
+	public function config() {
+		return Config::inst()->forClass(get_called_class());
+	}
+
+	/**
+	 * Defines the title of the job
+	 * @return string
+	 */
+	public function getTitle() {
+		return _t(
+			'CleanupJob.Title',
+			"Clean up old jobs from the database"
+		);
+	}
+
+	/**
+	 * Set immediacy of job
+	 * @return int
+	 */
+	public function getJobType() {
+		$this->totalSteps = '1';
+		return QueuedJob::IMMEDIATE;
+	}
+
+	/**
+	 * Clear out stale jobs based on the cleanup values
+	 */
+	public function process() {
+		$statusList = implode('\', \'', $this->config()->cleanup_statuses);
+		switch($this->config()->cleanup_method) {
+			// If Age, we need to get jobs that are at least n days old
+			case "age":
+				$cutOff = date("Y-m-d H:i:s",
+					strtotime(SS_Datetime::now() .
+						" - " .
+						$this->config()->cleanup_value .
+						" days"
+					)
+				);
+				$stale = DB::query(
+					'SELECT "ID" 
+					FROM "QueuedJobDescriptor" 
+					WHERE "JobStatus" 
+					IN (\'' . $statusList . '\')
+					AND "LastEdited" < \'' . $cutOff .'\''
+				);
+				$staleJobs = $stale->column("ID");
+				break;
+			// If Number, we need to save n records, then delete from the rest
+			case "number":
+				$fresh = DB::query(
+					'SELECT "ID" 
+					FROM "QueuedJobDescriptor" 
+					ORDER BY "LastEdited" 
+					ASC LIMIT ' . $this->config()->cleanup_value
+				);
+				$freshJobIDs = implode('\', \'', $fresh->column("ID"));
+
+				$stale = DB::query(
+					'SELECT "ID" 
+					FROM "QueuedJobDescriptor" 
+					WHERE "ID" 
+					NOT IN (\'' . $freshJobIDs . '\') 
+					AND "JobStatus" 
+					IN (\'' . $statusList . '\')'
+				);
+				$staleJobs = $stale->column("ID");
+				break;
+			default:
+				$this->addMessage("Incorrect configuration values set. Cleanup ignored");
+				$this->isComplete = true;
+				return;
+		}
+		if (empty($staleJobs)) {
+			$this->addMessage("No jobs to clean up.");
+			$this->isComplete = true;
+			return;
+		}
+		$numJobs = count($staleJobs);
+		$staleJobs = implode('\', \'', $staleJobs);
+		DB::query('DELETE FROM "QueuedJobDescriptor"
+			WHERE "ID"
+			IN (\'' . $staleJobs . '\')'
+		);
+		$this->addMessage($numJobs . " jobs cleaned up.");
+		// let's make sure there is a cleanupJob in the queue
+		if (Config::inst()->get('CleanupJob', 'is_enabled')) {
+		    $this->addMessage("Queueing the next Cleanup Job.");
+			$cleanup = new CleanupJob();
+			singleton('QueuedJobService')->queueJob($cleanup, date('Y-m-d H:i:s', time() + 86400));
+		}
+		$this->isComplete = true;
+		return;
+	}
+}

--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -615,7 +615,7 @@ class QueuedJobService {
 
 		Config::unnest();
 
-		// okay lets reset our user if we've got an original
+		// okay let's reset our user if we've got an original
 		if ($runAsUser && $originalUser) {
 			Session::clear("loggedInAs");
 			if ($originalUser) {

--- a/tests/CleanupJobFixture.yml
+++ b/tests/CleanupJobFixture.yml
@@ -1,0 +1,19 @@
+QueuedJobDescriptor:
+  first:
+    JobStatus: Complete
+    LastEdited: "01-01-01 01:01:01"
+  second:
+    JobStatus: Broken
+    LastEdited: "01-01-01 01:01:01"
+  third:
+    JobStatus: New
+    LastEdited: "01-01-01 01:01:01"
+  fourth:
+    JobStatus: Complete
+    LastEdited: "02-02-02 02:02:02"
+  fifth:
+    JobStatus: Broken
+    LastEdited: "02-02-02 02:02:02"
+  sixth:
+    JobStatus: New
+    LastEdited: "02-02-02 02:02:02"

--- a/tests/CleanupJobTest.php
+++ b/tests/CleanupJobTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @author Andrew Aitken-Fincham <andrew@silverstripe.com>
+ */
+class CleanupJobTest extends SapphireTest {
+
+    protected static $fixture_file = 'CleanupJobFixture.yml';
+
+    public function setUp() {
+        parent::setUp();
+        // Have to set a fake time here to work with 
+        // the LastEdited dates in the fixture
+        SS_Datetime::set_mock_now("02-02-03 02:02:02");
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+        SS_Datetime::clear_mock_now();
+    }
+
+    public function testByDays() {
+        $job = new CleanupJob();
+        Config::inst()->update('CleanupJob', 'cleanup_method', 'age');
+        Config::inst()->update('CleanupJob', 'cleanup_value', 30);
+        Config::inst()->remove('CleanupJob', 'cleanup_statuses');
+        Config::inst()->update('CleanupJob', 'cleanup_statuses',
+            array('Broken', 'Complete'));
+        $job->process();
+        $data = $job->getJobData();
+        $this->assertContains("2 jobs cleaned up.", $data->messages[0]);
+    }
+
+    public function testByNumber() {
+        $job = new CleanupJob();
+        Config::inst()->update('CleanupJob', 'cleanup_method', 'number');
+        Config::inst()->update('CleanupJob', 'cleanup_value', 3);
+        Config::inst()->remove('CleanupJob', 'cleanup_statuses');
+        Config::inst()->update('CleanupJob', 'cleanup_statuses',
+            array('Broken', 'Complete'));
+        $job->process();
+        $data = $job->getJobData();
+        $this->assertContains("2 jobs cleaned up.", $data->messages[0]);
+    }
+
+    public function testByStatus() {
+        $job = new CleanupJob();
+        Config::inst()->update('CleanupJob', 'cleanup_method', 'number');
+        Config::inst()->update('CleanupJob', 'cleanup_value', 3);
+        Config::inst()->remove('CleanupJob', 'cleanup_statuses');
+        Config::inst()->update('CleanupJob', 'cleanup_statuses',
+            array('Broken', 'Complete', 'New'));
+        $job->process();
+        $data = $job->getJobData();
+        $this->assertContains("3 jobs cleaned up.", $data->messages[0]);
+    }
+
+    public function testNoCleanup() {
+        $job = new CleanupJob();
+        Config::inst()->update('CleanupJob', 'cleanup_method', 'number');
+        Config::inst()->update('CleanupJob', 'cleanup_value', 6);
+        Config::inst()->remove('CleanupJob', 'cleanup_statuses');
+        Config::inst()->update('CleanupJob', 'cleanup_statuses',
+            array('Broken', 'Complete', 'New'));
+        $job->process();
+        $data = $job->getJobData();
+        $this->assertContains("No jobs to clean up.", $data->messages[0]);
+    }
+
+}


### PR DESCRIPTION
Fixes #44 

Introduces a CleanupJob that is off by default to ensure an upgrade wouldn't start destroying DB entries unexpectedly.

Cleans out anything in the DB with JobStatus "Complete" or "Broken" more than 30 days old in its default configuration. Can be tweaked to save n records, then clean out anything matching a valid status above that.

Tweaked the end of `runJob()` to ensure there is one CleanupJob in the queue, and if not, schedule on in for a day from then. Should mean that it runs once a day.
