### PR TITLE
added updateEditForm hook

### DIFF
--- a/code/controllers/QueuedJobsAdmin.php
+++ b/code/controllers/QueuedJobsAdmin.php
@@ -107,6 +107,8 @@ class QueuedJobsAdmin extends ModelAdmin {
 			$actions = $form->Actions();
 			$actions->push(FormAction::create('createjob', _t('QueuedJobs.CREATE_NEW_JOB', 'Create new job')));
 		}
+        
+        $this->extend('updateEditForm', $form);
 
 		return $form;
 	}


### PR DESCRIPTION
This hook is normally in ModelAdmin. Since it was missing it was not possible to edit the fields in QueuedJobsAdmin.