### PR TITLE
fix(JobErrorHandler): Output error messages in console again

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ By default the CleanupJob is disabled. To enable it, set the following in your Y
 CleanupJob:
   is_enabled: true
 ```
-This will ensure that the CleanupJob is run once a day.
+You will need to trigger the first run manually in the UI. After that the CleanupJob is run once a day.
 
 You can configure this job to clean up based on the number of jobs, or the age of the jobs. This is
 configured with the `cleanup_method` setting - current valid values are "age" (default)  and "number".

--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -540,7 +540,7 @@ class QueuedJobService {
 						} catch (Exception $e) {
 							// okay, we'll just catch this exception for now
 							$job->addMessage(sprintf(_t('QueuedJobs.JOB_EXCEPT', 'Job caused exception %s in %s at line %s'), $e->getMessage(), $e->getFile(), $e->getLine()), 'ERROR');
-							SS_Log::log($e, SS_Log::ERR);
+							$errorHandler->handleException($e);
 							$jobDescriptor->JobStatus =  QueuedJob::STATUS_BROKEN;
 						}
 
@@ -604,7 +604,7 @@ class QueuedJobService {
 				}
 			} catch (Exception $e) {
 				// okay, we'll just catch this exception for now
-				SS_Log::log($e, SS_Log::ERR);
+				$errorHandler->handleException($e);
 				$jobDescriptor->JobStatus =  QueuedJob::STATUS_BROKEN;
 				$jobDescriptor->write();
 				$broken = true;
@@ -844,25 +844,56 @@ class JobErrorHandler {
 		restore_error_handler();
 	}
 
+	/**
+	 * For logging and catching exceptions thrown during AbstractQueuedJob::process()
+	 * and similar.
+	 */ 
+	public function handleException($exception) {
+		$errno = E_USER_ERROR;
+		$type = get_class($exception);
+		$message = "Uncaught " . $type . ": " . $exception->getMessage();
+		$file = $exception->getFile();
+		$line = $exception->getLine();
+		$context = $exception->getTrace();
+
+		// NOTE: This will call SS_Log::log()
+		Debug::fatalHandler($errno, $message, $file, $line, $context);
+	}
+
+	/**
+	 * Works like the core Silverstripe error handler without exiting
+	 * on fatal messages.
+	 */ 
 	public function handleError($errno, $errstr, $errfile, $errline) {
 		if (error_reporting()) {
 			// Don't throw E_DEPRECATED in PHP 5.3+
-			if (defined('E_DEPRECATED')) {
-				if ($errno == E_DEPRECATED || $errno = E_USER_DEPRECATED) {
+			/*if (defined('E_DEPRECATED')) {
+				if ($errno == E_DEPRECATED || $errno == E_USER_DEPRECATED) {
 					return;
 				}
-			}
+			}*/
 
 			switch ($errno) {
 				case E_NOTICE:
 				case E_USER_NOTICE:
-				case E_STRICT: {
-					break;
-				}
-				default: {
-					throw new Exception($errstr . " in $errfile at line $errline", $errno);
-					break;
-				}
+				case E_DEPRECATED:
+				case E_USER_DEPRECATED:
+				case E_STRICT:
+					Debug::noticeHandler($errno, $errstr, $errfile, $errline, debug_backtrace());
+				break;
+
+				case E_WARNING:
+				case E_CORE_WARNING:
+				case E_USER_WARNING:
+				case E_RECOVERABLE_ERROR:
+					Debug::warningHandler($errno, $errstr, $errfile, $errline, debug_backtrace());
+				break;
+
+				default:
+					throw new ErrorException($errstr, $errno, $errno, $errfile, $errline);
+					// Old exception throw
+					//throw new Exception($errstr . " in $errfile at line $errline", $errno);
+				break;
 			}
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,5 @@
 		"silverstripe/framework": "~3.1",
 		"silverstripe/multivaluefield": "~2.0",
 		"asyncphp/doorman": "~1.2"
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "2.9.x-dev"
-		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
 		{
 			"name": "Marcus Nyeholt",
 			"email": "marcus@silverstripe.com.au"
+		},
+		{
+			"name": "Damian Mooyman",
+			"email": "damian@silverstripe.com"
 		}
 	],
 	"require":


### PR DESCRIPTION
**WARNING: This fix seems to mess with composer.json in unintended ways, what should I be doing here?**

fix(JobErrorHandler): Fix bug where deprecation / variable set in if-statement would always cause zero outputting of errors to console. Modified logic to align with Core silverstripe functions.

Culprit:
https://github.com/silverstripe-australia/silverstripe-queuedjobs/blob/master/src/Services/QueuedJobService.php#L969