### PR TITLE
Fix markStarted not calculating timeout correctly

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -713,7 +713,7 @@ class QueuedJobService
      */
     protected function markStarted()
     {
-        if ($this->startedAt) {
+        if (!$this->startedAt) {
             $this->startedAt = DBDatetime::now()->Format('U');
         }
     }


### PR DESCRIPTION
As far as I can see setting a `time_limit` simply doesn't work, as `startedAt` is always 0.
Seems to work for me if `startedAt` gets set as I'd expect.