### PR TITLE
Thread safe job locking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ dist: trusty
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
-    - php: 7.0
+    - php: 7.1
       env: DB=PGSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
     - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "php": "^7.1",
         "silverstripe/framework": "^4",
         "silverstripe/admin": "^1",
         "asyncphp/doorman": "^3.0"

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -37,6 +37,10 @@ use Symbiote\QueuedJobs\Services\QueuedJobService;
  * @property string $SavedJobMessages List of messages saved for this job
  * @property string $JobStatus Status of this job
  * @property string $JobType Type of job
+ * @property string $Worker
+ * @property string $Expiry
+ * @property bool $NotifiedBroken
+ * @property int $WorkerCount
  *
  * @method Member RunAs() Member to run this job as
  *
@@ -70,6 +74,10 @@ class QueuedJobDescriptor extends DataObject
         'SavedJobMessages' => 'Text',
         'JobStatus' => 'Varchar(16)',
         'JobType' => 'Varchar(16)',
+        'Worker' => 'Varchar(32)',
+        'Expiry' => 'DBDatetime',
+        'NotifiedBroken' => 'Boolean',
+        'WorkerCount' => 'Int',
     ];
 
     /**

--- a/src/Services/EmailService.php
+++ b/src/Services/EmailService.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Services;
+
+use SilverStripe\Control\Director;
+use SilverStripe\Control\Email\Email;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Subsites\Model\Subsite;
+
+/**
+ * Class EmailService
+ *
+ * Email reporting for queued jobs
+ *
+ * @package Symbiote\QueuedJobs\Services
+ */
+class EmailService
+{
+    use Injectable;
+
+    public function __construct()
+    {
+        $queuedEmail = Config::inst()->get(Email::class, 'queued_job_admin_email');
+
+        if ($queuedEmail || $queuedEmail === false) {
+            return;
+        }
+
+        // if not set (and not explictly set to false), fallback to the admin email.
+        Config::modify()->set(
+            Email::class,
+            'queued_job_admin_email',
+            Config::inst()->get(Email::class, 'admin_email')
+        );
+    }
+
+    /**
+     * @param array $jobConfig
+     * @param string $title
+     * @return Email|null
+     */
+    public function createMissingDefaultJobReport(array $jobConfig, string $title): ?Email
+    {
+        $subject = sprintf('Default Job "%s" missing', $title);
+        $from = Config::inst()->get('Email', 'queued_job_admin_email');
+        $to = array_key_exists('email', $jobConfig) &&  $jobConfig['email']
+            ? $jobConfig['email']
+            : $from;
+
+        if (!$to) {
+            return null;
+        }
+
+        return Email::create($from, $to, $subject)
+            ->setData($jobConfig)
+            ->addData('Title', $title)
+            ->addData('Site', Director::absoluteBaseURL())
+            ->setHTMLTemplate('QueuedJobsDefaultJob');
+    }
+
+    /**
+     * @param string $subject
+     * @param string $message
+     * @param int $jobID
+     * @return Email|null
+     */
+    public function createStalledJobReport(string $subject, string $message, int $jobID): ?Email
+    {
+        $email = $this->createReport($subject);
+        if ($email === null) {
+            return null;
+        }
+
+        return $email
+            ->setData([
+                'JobID' => $jobID,
+                'Message' => $message,
+                'Site' => Director::absoluteBaseURL(),
+            ])
+            ->setHTMLTemplate('QueuedJobsStalledJob');
+    }
+
+    /**
+     * Create a generic email report
+     * useful for reporting queue service issues
+     *
+     * @param string $subject
+     * @return Email|null
+     */
+    public function createReport(string $subject): ?Email
+    {
+        $from = Config::inst()->get(Email::class, 'admin_email');
+        $to = Config::inst()->get(Email::class, 'queued_job_admin_email');
+
+        if (!$to) {
+            return null;
+        }
+
+        return Email::create($from, $to, $subject);
+    }
+}

--- a/src/Services/JobErrorHandler.php
+++ b/src/Services/JobErrorHandler.php
@@ -3,12 +3,15 @@
 namespace Symbiote\QueuedJobs\Services;
 
 use Exception;
+use SilverStripe\Core\Injector\Injectable;
 
 /**
  * Class used to handle errors for a single job
  */
 class JobErrorHandler
 {
+    use Injectable;
+
     public function __construct()
     {
         set_error_handler(array($this, 'handleError'));


### PR DESCRIPTION
# Thread safe job locking

This change-set introduces a thread safe job locking mechanism. It relies on Database features such as:

* transactions
* `SELECT FOR UPDATE`
* unique id generated for specific process

## Other changes

* multiple jobs are allowed to run at the same time by different processes as we can rely on job locking to prevent one jobs from being run more than once
* job run method uses now callback style for transactions, config nesting and log flushing
* `PHP 7.1` or higher is required
* each broken job is only reported once
* `JobErrorHandler` is now Injectible
* email related functionality moved to a separate service (no functionality changes)

## Related issues

https://github.com/symbiote/silverstripe-queuedjobs/issues/280