### PR TITLE
Fix QueuedJobsAdmin parsing job parameters

### DIFF
--- a/src/Controllers/QueuedJobsAdmin.php
+++ b/src/Controllers/QueuedJobsAdmin.php
@@ -189,7 +189,7 @@ class QueuedJobsAdmin extends ModelAdmin
     {
         if (Permission::check('ADMIN')) {
             $jobType = isset($data['JobType']) ? $data['JobType'] : '';
-            $params = isset($data['JobParams']) ? explode(PHP_EOL, $data['JobParams']) : array();
+            $params = isset($data['JobParams']) ? preg_split('/\R/', trim($data['JobParams'])) : [];
 
             if (isset($data['JobStart'])) {
                 $time = is_array($data['JobStart']) ? implode(' ', $data['JobStart']) : $data['JobStart'];

--- a/tests/Jobs/TestDummyJob.php
+++ b/tests/Jobs/TestDummyJob.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Tests\Jobs;
+
+use SilverStripe\Dev\TestOnly;
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+
+/**
+ * Test dummy job for capturing data and not doing anything
+ */
+class TestDummyJob extends AbstractQueuedJob implements TestOnly
+{
+    /**
+     * Parameters passed to the constructor
+     *
+     * @var array
+     */
+    public $constructParams;
+
+    public function __construct($params = [])
+    {
+        parent::__construct();
+        $this->constructParams = func_get_args();
+    }
+
+    public function getTitle()
+    {
+        return static::class;
+    }
+
+    public function process()
+    {
+        // no op
+    }
+}

--- a/tests/QueuedJobsAdminTest.php
+++ b/tests/QueuedJobsAdminTest.php
@@ -12,6 +12,7 @@ use SilverStripe\ORM\FieldType\DBDatetime;
 use Symbiote\QueuedJobs\Controllers\QueuedJobsAdmin;
 use Symbiote\QueuedJobs\Jobs\PublishItemsJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
+use Symbiote\QueuedJobs\Tests\Jobs\TestDummyJob;
 
 /**
  * Tests for the QueuedJobsAdmin ModelAdmin clas
@@ -81,12 +82,15 @@ class QueuedJobsAdminTest extends FunctionalTest
             ->expects($this->once())
             ->method('queueJob')
             ->with($this->callback(function ($job) {
-                return $job instanceof PublishItemsJob && $job->rootID === 'foo123';
+                $this->assertInstanceOf(TestDummyJob::class, $job);
+                $this->assertEquals(['foo', 'bar', 'baz', 'qux'], $job->constructParams);
+
+                return true;
             }));
 
         $form = $this->admin->getEditForm('foo', new FieldList());
-        $form->Fields()->fieldByName('JobParams')->setValue(implode(PHP_EOL, ['foo123', 'bar']));
-        $form->Fields()->fieldByName('JobType')->setValue(PublishItemsJob::class);
+        $form->Fields()->fieldByName('JobParams')->setValue("foo\nbar\rbaz\r\nqux");
+        $form->Fields()->fieldByName('JobType')->setValue(TestDummyJob::class);
 
         $this->admin->createjob($form->getData(), $form);
     }


### PR DESCRIPTION
QueuedJobsAdmin would try to split parameters by PHP_EOL,
which is a single newline (LF aka "\n") on unix based systems.
That causes incorrect argument parsing when browsers send
CRLF ("\r\n").

Fixes https://github.com/symbiote/silverstripe-queuedjobs/issues/258