### PR TITLE
BUG SilverStripe 4 upgrade fix

### DIFF
--- a/src/Services/EmailService.php
+++ b/src/Services/EmailService.php
@@ -43,7 +43,7 @@ class EmailService
     public function createMissingDefaultJobReport(array $jobConfig, string $title): ?Email
     {
         $subject = sprintf('Default Job "%s" missing', $title);
-        $from = Config::inst()->get('Email', 'queued_job_admin_email');
+        $from = Config::inst()->get(Email::class, 'queued_job_admin_email');
         $to = array_key_exists('email', $jobConfig) &&  $jobConfig['email']
             ? $jobConfig['email']
             : $from;


### PR DESCRIPTION
This fixes an outdated class reference which was missed during SilverStripe 4 upgrade

This issue was detected but not caused in https://github.com/symbiote/silverstripe-queuedjobs/pull/279

## Related issues

https://github.com/symbiote/silverstripe-queuedjobs/issues/286