### PR TITLE
BUG: Broken job handling when setup() throws

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -1077,7 +1077,7 @@ class QueuedJobService
      * @param QueuedJob|null $job
      * @param Exception|\Throwable $e
      */
-    protected function handleBrokenJobException(QueuedJobDescriptor $jobDescriptor, $job, $e)
+    protected function handleBrokenJobException(QueuedJobDescriptor $jobDescriptor, ?QueuedJob $job, $e)
     {
         // okay, we'll just catch this exception for now
         $this->getLogger()->info(

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -1074,10 +1074,10 @@ class QueuedJobService
 
     /**
      * @param QueuedJobDescriptor $jobDescriptor
-     * @param QueuedJob $job
+     * @param QueuedJob|null $job
      * @param Exception|\Throwable $e
      */
-    protected function handleBrokenJobException(QueuedJobDescriptor $jobDescriptor, QueuedJob $job, $e)
+    protected function handleBrokenJobException(QueuedJobDescriptor $jobDescriptor, $job, $e)
     {
         // okay, we'll just catch this exception for now
         $this->getLogger()->info(
@@ -1087,6 +1087,7 @@ class QueuedJobService
             ]
         );
         $jobDescriptor->JobStatus =  QueuedJob::STATUS_BROKEN;
+        // $job may be null if the exception was thrown by setup()
         $this->extend('updateJobDescriptorAndJobOnException', $jobDescriptor, $job, $e);
         $jobDescriptor->write();
     }


### PR DESCRIPTION
Apply the https://github.com/symbiote/silverstripe-queuedjobs/pull/263 to `4`