### PR TITLE
BUGFIX: ['stalled'] needs to be defined to print values

### DIFF
--- a/src/Tasks/CheckJobHealthTask.php
+++ b/src/Tasks/CheckJobHealthTask.php
@@ -2,6 +2,7 @@
 
 namespace Symbiote\QueuedJobs\Tasks;
 
+use Exception;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
 use Symbiote\QueuedJobs\Services\QueuedJob;
@@ -34,6 +35,8 @@ class CheckJobHealthTask extends BuildTask
      *
      * @param HTTPRequest $request
      * @return
+     *
+     * @throws Exception
      */
     public function run($request)
     {
@@ -48,11 +51,11 @@ class CheckJobHealthTask extends BuildTask
             $unhealthyJobCount = $unhealthyJobCount + $count;
         }
 
-        if ($unhealthyJobCount === 0) {
-            echo 'All jobs are healthy';
-        } else {
-            die(1);
+        if ($unhealthyJobCount > 0) {
+            throw new Exception("$unhealthyJobCount jobs are unhealthy");
         }
+
+        echo 'All jobs are healthy';
     }
 
     protected function getService()

--- a/src/Tasks/CheckJobHealthTask.php
+++ b/src/Tasks/CheckJobHealthTask.php
@@ -38,11 +38,21 @@ class CheckJobHealthTask extends BuildTask
     public function run($request)
     {
         $queue = $request->requestVar('queue') ?: QueuedJob::QUEUED;
+        $jobHealth = $this->getService()->checkJobHealth($queue);
 
-        $stalledJobCount = $this->getService()->checkJobHealth($queue);
+        $unhealthyJobCount = 0;
 
-        echo $stalledJobCount === 0 ? 'All jobs are healthy' : 'Detected and attempted restart on ' . $stalledJobCount .
-            ' stalled jobs';
+        foreach ( $jobHealth as $type => $IDs ) {
+            $count = count($IDs);
+            echo 'Detected and attempted restart on ' . $count . ' ' . $type . ' jobs';
+            $unhealthyJobCount = $unhealthyJobCount + $count;
+        }
+
+        if( $unhealthyJobCount === 0 ) {
+            echo 'All jobs are healthy';
+        } else {
+            die(1);
+        }
     }
 
     protected function getService()

--- a/src/Tasks/CheckJobHealthTask.php
+++ b/src/Tasks/CheckJobHealthTask.php
@@ -42,13 +42,13 @@ class CheckJobHealthTask extends BuildTask
 
         $unhealthyJobCount = 0;
 
-        foreach ( $jobHealth as $type => $IDs ) {
+        foreach ($jobHealth as $type => $IDs) {
             $count = count($IDs);
             echo 'Detected and attempted restart on ' . $count . ' ' . $type . ' jobs';
             $unhealthyJobCount = $unhealthyJobCount + $count;
         }
 
-        if( $unhealthyJobCount === 0 ) {
+        if ($unhealthyJobCount === 0) {
             echo 'All jobs are healthy';
         } else {
             die(1);


### PR DESCRIPTION
`$this->getService()->checkJobHealth($queue);` returns an array which  means `echo $stalledJobCount === 0` fails. I have updated this to show some logical output and also added an exit(1) for when this is run from cli to detect unhealthy jobs.

Any feedback welcome.