### PR TITLE
NEW: Task runner better UI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.yml,package.json}]
-indent_size = 2
+[{*.yml,*.ss,*.css,*.json}]
+indent_size = 4
+indent_style = space
 
 # The indent size used in the package.json file cannot be changed:
 # https://github.com/npm/npm/pull/3180#issuecomment-16336516

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,22 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.yml,*.ss,*.css,*.json}]
-indent_size = 4
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,js,json,css,scss,eslintrc,feature}]
+indent_size = 2
 indent_style = space
 
-# The indent size used in the package.json file cannot be changed:
-# https://github.com/npm/npm/pull/3180#issuecomment-16336516
+[composer.json]
+indent_size = 4
+
+# Don't perform any clean-up on thirdparty files
+
+[thirdparty/**]
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[admin/thirdparty/**]
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,13 @@ dist: trusty
 matrix:
   include:
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=^4.7 PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=PGSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
-    - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=^4.7 PHPUNIT_TEST=1
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=^4.7 PHPUNIT_TEST=1
     - php: 7.3
-      env: DB=MYSQL RECIPE_VERSION=4.5.x-dev PHPUNIT_TEST=1
-    - php: 7.3
-      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=^4.7 PHPUNIT_TEST=1
     - php: 7.4
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -11,20 +11,8 @@
 .task__selector {
     display: inline-block;
     height: 42px;
-    margin: 0 0 0 15px;
+    margin: 0;
     visibility: hidden;
-}
-
-.task__selector--universal {
-  width: 105px;
-}
-
-.task__selector--immediate {
-  width: 144px;
-}
-
-.task__selector--queue-only {
-  width: 146px;
 }
 
 .task__selector:checked + .task__label .task__label-inner,
@@ -37,21 +25,6 @@
     transform: translateY(-15px);
 }
 
-.task__label--universal {
-  margin-left: -109px;
-  width: 105px;
-}
-
-.task__label--immediate {
-  margin-left: -147px;
-  width: 144px;
-}
-
-.task__label--queue-only {
-  margin-left: -150px;
-  width: 146px;
-}
-
 .task__label-inner {
   border-bottom: 2px solid transparent;
   padding-bottom: 15px;
@@ -62,12 +35,13 @@
     margin-left: 0;
 }
 
-.task__panel {
+.task__panel .task__item {
     display: none;
 }
 
-.task__selector--immediate:checked ~ .task__panel--immediate,
-.task__selector--universal:checked ~ .task__panel--universal,
-.task__selector--queue-only:checked ~ .task__panel--queue-only {
-    display: block;
+.task__selector--immediate:checked ~ .task__panel .task__item--immediate,
+.task__selector--universal:checked ~ .task__panel .task__item--universal,
+.task__selector--queue-only:checked ~ .task__panel .task__item--queue-only,
+.task__selector--all:checked ~ .task__panel .task__item {
+    display: inline-block;
 }

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -54,5 +54,5 @@
 }
 
 .task__button + .task__button {
-    margin-left: 25px;
+    margin-left: 5px;
 }

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -29,7 +29,7 @@
 
 .task__selector:checked + .task__label .task__label-inner,
 .task__selector:hover + .task__label .task__label-inner {
-  border-bottom-color: #475266;
+  border-bottom-color: #43536d;
 }
 
 .task__label {
@@ -54,7 +54,7 @@
 
 .task__label-inner {
   border-bottom: 2px solid transparent;
-  padding-bottom: 10px;
+  padding-bottom: 15px;
   transition: border-bottom-color 0.2s;
 }
 

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -1,38 +1,61 @@
 /* This file is manually maintained, it is not generated from SCSS sources */
 
+.task {
+  padding-top: 10px;
+}
+
+.task__panel {
+  padding: 10px 15px 15px 15px;
+}
+
 .task__selector {
     display: inline-block;
     height: 42px;
-    margin: 0;
-    opacity: 0.2;
-    transform: translateX(-203px);
-    width: 199px;
+    margin: 0 0 0 15px;
+    visibility: hidden;
 }
 
-.task__selector:after {
-    background-color: #5c5c5c;
-    content: ' ';
-    display: inline-block;
-    height: 42px;
-    transition: all 0.2s;
-    width: 199px;
+.task__selector--universal {
+  width: 105px;
 }
 
-.task__selector:checked:after,
-.task__selector:hover:after {
-    background-color: #000000;
+.task__selector--immediate {
+  width: 144px;
+}
+
+.task__selector--queue-only {
+  width: 146px;
+}
+
+.task__selector:checked + .task__label .task__label-inner,
+.task__selector:hover + .task__label .task__label-inner {
+  border-bottom-color: #475266;
 }
 
 .task__label {
-    border-bottom: 1px solid #000000;
-    border-right: 1px solid #000000;
     display: inline-block;
-    font-weight: bold;
-    margin-left: -208px;
-    padding: 10px 20px;
-    text-align: center;
     transform: translateY(-15px);
-    width: 158px;
+}
+
+.task__label--universal {
+  margin-left: -109px;
+  width: 105px;
+}
+
+.task__label--immediate {
+  margin-left: -147px;
+  width: 144px;
+}
+
+.task__label--queue-only {
+  margin-left: -150px;
+  width: 146px;
+}
+
+.task__label-inner {
+  border-bottom: 2px solid transparent;
+  padding-bottom: 10px;
+  transition: border-bottom-color 0.2s;
 }
 
 .task__label:first-child {
@@ -47,12 +70,4 @@
 .task__selector--universal:checked ~ .task__panel--universal,
 .task__selector--queue-only:checked ~ .task__panel--queue-only {
     display: block;
-}
-
-.task__button--notice:hover {
-    background-color: #ebffeb;
-}
-
-.task__button + .task__button {
-    margin-left: 5px;
 }

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -1,0 +1,58 @@
+/* This file is manually maintained, it is not generated from SCSS sources */
+
+.task__selector {
+    display: inline-block;
+    height: 42px;
+    margin: 0;
+    opacity: 0.2;
+    transform: translateX(-203px);
+    width: 199px;
+}
+
+.task__selector:after {
+    background-color: #5c5c5c;
+    content: ' ';
+    display: inline-block;
+    height: 42px;
+    transition: all 0.2s;
+    width: 199px;
+}
+
+.task__selector:checked:after,
+.task__selector:hover:after {
+    background-color: #000000;
+}
+
+.task__label {
+    border-bottom: 1px solid #000000;
+    border-right: 1px solid #000000;
+    display: inline-block;
+    font-weight: bold;
+    margin-left: -208px;
+    padding: 10px 20px;
+    text-align: center;
+    transform: translateY(-15px);
+    width: 158px;
+}
+
+.task__label:first-child {
+    margin-left: 0;
+}
+
+.task__panel {
+    display: none;
+}
+
+.task__selector--immediate:checked ~ .task__panel--immediate,
+.task__selector--universal:checked ~ .task__panel--universal,
+.task__selector--queue-only:checked ~ .task__panel--queue-only {
+    display: block;
+}
+
+.task__button--notice:hover {
+    background-color: #ebffeb;
+}
+
+.task__button + .task__button {
+    margin-left: 25px;
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "silverstripe/framework": "^4",
+        "silverstripe/framework": "^4.7",
         "silverstripe/admin": "^1",
         "asyncphp/doorman": "^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
     "extra": {
         "branch-alias": {
             "dev-master": "4.x-dev"
-        }
+        },
+        "expose": [
+            "client/styles"
+        ]
     },
     "replace": {
         "silverstripe/queuedjobs": "self.version"

--- a/src/Controllers/QueuedTaskRunner.php
+++ b/src/Controllers/QueuedTaskRunner.php
@@ -7,9 +7,13 @@ use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Manifest\ModuleResourceLoader;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\Dev\DebugView;
 use SilverStripe\Dev\TaskRunner;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\View\ArrayData;
+use SilverStripe\View\ViewableData;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 use Symbiote\QueuedJobs\Jobs\RunBuildTaskJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
@@ -62,6 +66,12 @@ class QueuedTaskRunner extends TaskRunner
 
     public function index()
     {
+        if (Director::is_cli()) {
+            // CLI mode - revert to default behaviour
+            return parent::index();
+        }
+
+        $baseUrl = Director::absoluteBaseURL();
         $tasks = $this->getTasks();
 
         $blacklist = (array) $this->config()->get('task_blacklist');
@@ -69,78 +79,78 @@ class QueuedTaskRunner extends TaskRunner
         $backlistedTasks = [];
         $queuedOnlyTasks = [];
 
-        // Web mode
-        if (!Director::is_cli()) {
-            $renderer = new DebugView();
-            echo $renderer->renderHeader();
-            echo $renderer->renderInfo(
-                "SilverStripe Development Tools: Tasks (QueuedJobs version)",
-                Director::absoluteBaseURL()
-            );
-            $base = Director::absoluteBaseURL();
+        // universal tasks
+        $universalTaskList = ArrayList::create();
 
-            echo "<div class=\"options\">";
-            echo "<h2>Queueable jobs</h2>\n";
-            echo "<p>By default these jobs will be added the job queue, rather than run immediately</p>\n";
-            echo "<ul>";
-            foreach ($tasks as $task) {
-                if (in_array($task['class'], $blacklist)) {
-                    $backlistedTasks[] = $task;
+        foreach ($tasks as $task) {
+            if (in_array($task['class'], $blacklist)) {
+                $backlistedTasks[] = $task;
 
-                    continue;
-                }
-
-                if (in_array($task['class'], $queuedOnlyList)) {
-                    $queuedOnlyTasks[] = $task;
-
-                    continue;
-                }
-
-                $queueLink = $base . "dev/tasks/queue/" . $task['segment'];
-                $immediateLink = $base . "dev/tasks/" . $task['segment'];
-
-                echo "<li><p>";
-                echo "<a href=\"$queueLink\">" . $task['title'] . "</a> <a style=\"font-size: 80%; padding-left: 20px\""
-                    . " href=\"$immediateLink\">[run immediately]</a><br />";
-                echo "<span class=\"description\">" . $task['description'] . "</span>";
-                echo "</p></li>\n";
+                continue;
             }
-            echo "</ul></div>";
 
-            echo "<div class=\"options\">";
-            echo "<h2>Non-queueable tasks</h2>\n";
-            echo "<p>These tasks shouldn't be added the queuejobs queue, but you can run them immediately.</p>\n";
-            echo "<ul>";
-            foreach ($backlistedTasks as $task) {
-                $immediateLink = $base . "dev/tasks/" . $task['segment'];
+            if (in_array($task['class'], $queuedOnlyList)) {
+                $queuedOnlyTasks[] = $task;
 
-                echo "<li><p>";
-                echo "<a href=\"$immediateLink\">" . $task['title'] . "</a><br />";
-                echo "<span class=\"description\">" . $task['description'] . "</span>";
-                echo "</p></li>\n";
+                continue;
             }
-            echo "</ul></div>";
 
-            echo "<div class=\"options\">";
-            echo "<h2>Queueable only tasks</h2>\n";
-            echo "<p>These tasks must be be added the queuejobs queue, running it immediately is not allowed.</p>\n";
-            echo "<ul>";
-            foreach ($queuedOnlyTasks as $task) {
-                $queueLink = $base . "dev/tasks/queue/" . $task['segment'];
-
-                echo "<li><p>";
-                echo "<a href=\"$queueLink\">" . $task['title'] . "</a><br />";
-                echo "<span class=\"description\">" . $task['description'] . "</span>";
-                echo "</p></li>\n";
-            }
-            echo "</ul></div>";
-
-            echo $renderer->renderFooter();
-
-            // CLI mode - revert to default behaviour
-        } else {
-            return parent::index();
+            $universalTaskList->push(ArrayData::create([
+                'QueueLink' => $baseUrl . 'dev/tasks/queue/' . $task['segment'],
+                'TaskLink' => $baseUrl . 'dev/tasks/' . $task['segment'],
+                'Title' => $task['title'],
+                'Description' => $task['description'],
+            ]));
         }
+
+        // Non-queueable tasks
+        $immediateTaskList = ArrayList::create();
+
+        foreach ($backlistedTasks as $task) {
+            $immediateTaskList->push(ArrayData::create([
+                'TaskLink' => $baseUrl . 'dev/tasks/' . $task['segment'],
+                'Title' => $task['title'],
+                'Description' => $task['description'],
+            ]));
+        }
+
+        // Queue only tasks
+        $queueOnlyTaskList = ArrayList::create();
+
+        foreach ($queuedOnlyTasks as $task) {
+            $queueOnlyTaskList->push(ArrayData::create([
+                'QueueLink' => $baseUrl . 'dev/tasks/queue/' . $task['segment'],
+                'Title' => $task['title'],
+                'Description' => $task['description'],
+            ]));
+        }
+
+        $renderer = DebugView::create();
+        $header = $renderer->renderHeader();
+
+        $cssIncludes = [
+            'silverstripe/framework:client/styles/task-runner.css',
+            'symbiote/silverstripe-queuedjobs:client/styles/task-runner.css',
+        ];
+
+        foreach ($cssIncludes as $cssResource) {
+            $cssPath = ModuleResourceLoader::singleton()->resolveURL($cssResource);
+
+            // inject CSS into the heaader
+            $cssInclude = sprintf('<link rel="stylesheet" type="text/css" href="%s" />', $cssPath);
+            $header = str_replace('</head>', $cssInclude . '</head>', $header);
+        }
+
+        $data = [
+            'UniversalTasks' => $universalTaskList,
+            'ImmediateTasks' => $immediateTaskList,
+            'QueueOnlyTasks' => $queueOnlyTaskList,
+            'Header' => $header,
+            'Footer' => $renderer->renderFooter(),
+            'Info' => $renderer->renderInfo('SilverStripe Development Tools: Tasks (QueuedJobs version)', $baseUrl),
+        ];
+
+        return ViewableData::create()->renderWith(static::class, $data);
     }
 
 

--- a/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
+++ b/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
@@ -2,29 +2,33 @@ $Header.RAW
 $Info.RAW
 
 <div class="task">
-    <label class="task__label" for="tab-universal-tasks">Queueable task</label>
     <input type="radio" id="tab-universal-tasks" class="task__selector task__selector--universal" name="task__selector" checked="checked" />
-    <label class="task__label" for="tab-immediate-tasks">Non-queueable tasks</label>
+    <label class="task__label task__label--universal" for="tab-universal-tasks">
+        <span class="task__label-inner">Queueable task</span>
+    </label>
+
     <input type="radio" id="tab-immediate-tasks" class="task__selector task__selector--immediate" name="task__selector" />
-    <label class="task__label" for="tab-queue-only-tasks">Queueable only tasks</label>
+    <label class="task__label task__label--immediate" for="tab-immediate-tasks">
+        <span class="task__label-inner">Non-queueable tasks</span>
+    </label>
+
     <input type="radio" id="tab-queue-only-tasks" class="task__selector task__selector--queue-only" name="task__selector" />
+    <label class="task__label task__label--queue-only" for="tab-queue-only-tasks">
+        <span class="task__label-inner">Queueable only tasks</span>
+    </label>
 
     <div class="task__panel task__panel--universal">
-        <div class="task__intro">
-            <h2>Queueable tasks</h2>
-            <p>By default these jobs will be added the job queue, rather than run immediately.</p>
-        </div>
         <% if $UniversalTasks.Count > 0 %>
             <div class="task__list">
                 <% loop $UniversalTasks %>
                     <div class="task__item">
                         <div>
-                            <h3>$Title</h3>
-                            <p class="description">$Description</p>
+                            <h3 class="task__title">$Title</h3>
+                            <p class="task__description">$Description</p>
                         </div>
                         <div>
-                            <a href="{$TaskLink.ATT}" class="task__button task__button--warning">Run immediately</a>
-                            <a href="{$QueueLink.ATT}" class="task__button task__button--notice">Add to queue</a>
+                            <a href="{$TaskLink.ATT}" class="task__button">Run task</a>
+                            <a href="{$QueueLink.ATT}" class="task__button">Queue job</a>
                         </div>
                     </div>
                 <% end_loop %>
@@ -33,10 +37,6 @@ $Info.RAW
     </div>
 
     <div class="task__panel task__panel--immediate">
-        <div class="task__intro">
-            <h2>Non-queueable tasks</h2>
-            <p>These tasks shouldn't be added the queuejobs queue, but you can run them immediately.</p>
-        </div>
         <% if $ImmediateTasks.Count > 0 %>
             <div class="task__list">
                 <% loop $ImmediateTasks %>
@@ -55,10 +55,6 @@ $Info.RAW
     </div>
 
     <div class="task__panel task__panel--queue-only">
-        <div class="task__intro">
-            <h2>Queueable only tasks</h2>
-            <p>These tasks must be be added the queuejobs queue, running it immediately is not allowed.</p>
-        </div>
         <% if $QueueOnlyTasks.Count > 0 %>
             <div class="task__list">
                 <% loop $QueueOnlyTasks %>

--- a/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
+++ b/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
@@ -24,7 +24,7 @@ $Info.RAW
                     <div class="task__item">
                         <div>
                             <h3 class="task__title">$Title</h3>
-                            <p class="task__description">$Description</p>
+                            <div class="task__description">$Description</div>
                         </div>
                         <div>
                             <a href="{$TaskLink.ATT}" class="task__button">Run task</a>

--- a/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
+++ b/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
@@ -2,7 +2,12 @@ $Header.RAW
 $Info.RAW
 
 <div class="task">
-    <input type="radio" id="tab-universal-tasks" class="task__selector task__selector--universal" name="task__selector" checked="checked" />
+    <input type="radio" id="tab-all-tasks" class="task__selector task__selector--all" name="task__selector" checked="checked" />
+    <label class="task__label task__label--all" for="tab-all-tasks">
+        <span class="task__label-inner">All tasks</span>
+    </label>
+
+    <input type="radio" id="tab-universal-tasks" class="task__selector task__selector--universal" name="task__selector" />
     <label class="task__label task__label--universal" for="tab-universal-tasks">
         <span class="task__label-inner">Queueable task</span>
     </label>
@@ -17,54 +22,23 @@ $Info.RAW
         <span class="task__label-inner">Queueable only tasks</span>
     </label>
 
-    <div class="task__panel task__panel--universal">
-        <% if $UniversalTasks.Count > 0 %>
+    <div class="task__panel">
+        <% if $Tasks.Count > 0 %>
             <div class="task__list">
-                <% loop $UniversalTasks %>
-                    <div class="task__item">
+                <% loop $Tasks %>
+                    <div class="task__item task__item--{$Type}">
                         <div>
                             <h3 class="task__title">$Title</h3>
                             <div class="task__description">$Description</div>
                         </div>
                         <div>
-                            <a href="{$TaskLink.ATT}" class="task__button">Run task</a>
-                            <a href="{$QueueLink.ATT}" class="task__button">Queue job</a>
-                        </div>
-                    </div>
-                <% end_loop %>
-            </div>
-        <% end_if %>
-    </div>
+                            <% if $TaskLink %>
+                                <a href="{$TaskLink.ATT}" class="task__button">Run task</a>
+                            <% end_if %>
 
-    <div class="task__panel task__panel--immediate">
-        <% if $ImmediateTasks.Count > 0 %>
-            <div class="task__list">
-                <% loop $ImmediateTasks %>
-                    <div class="task__item">
-                        <div>
-                            <h3 class="task__title">$Title</h3>
-                            <div class="task__description">$Description</div>
-                        </div>
-                        <div>
-                            <a href="{$TaskLink.ATT}" class="task__button">Run task</a>
-                        </div>
-                    </div>
-                <% end_loop %>
-            </div>
-        <% end_if %>
-    </div>
-
-    <div class="task__panel task__panel--queue-only">
-        <% if $QueueOnlyTasks.Count > 0 %>
-            <div class="task__list">
-                <% loop $QueueOnlyTasks %>
-                    <div class="task__item">
-                        <div>
-                            <h3 class="task__title">$Title</h3>
-                            <div class="task__description">$Description</div>
-                        </div>
-                        <div>
-                            <a href="{$QueueLink.ATT}" class="task__button">Queue job</a>
+                            <% if $QueueLink %>
+                                <a href="{$QueueLink.ATT}" class="task__button">Queue job</a>
+                            <% end_if %>
                         </div>
                     </div>
                 <% end_loop %>

--- a/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
+++ b/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
@@ -1,0 +1,74 @@
+$Header.RAW
+$Info.RAW
+
+<div class="task">
+    <label class="task__label" for="tab-universal-tasks">Queueable task</label>
+    <input type="radio" id="tab-universal-tasks" class="task__selector task__selector--universal" name="task__selector" checked="checked" />
+    <label class="task__label" for="tab-immediate-tasks">Non-queueable tasks</label>
+    <input type="radio" id="tab-immediate-tasks" class="task__selector task__selector--immediate" name="task__selector" />
+    <label class="task__label" for="tab-queue-only-tasks">Queueable only tasks</label>
+    <input type="radio" id="tab-queue-only-tasks" class="task__selector task__selector--queue-only" name="task__selector" />
+
+    <div class="task__panel task__panel--universal">
+        <h2>Queueable tasks</h2>
+        <p>By default these jobs will be added the job queue, rather than run immediately.</p>
+        <% if $UniversalTasks.Count > 0 %>
+            <div class="task__list">
+                <% loop $UniversalTasks %>
+                    <div class="task__item">
+                        <div>
+                            <h3>$Title</h3>
+                            <p class="description">$Description</p>
+                        </div>
+                        <div>
+                            <a href="{$TaskLink.ATT}" class="task__button task__button--warning">Run immediately</a>
+                            <a href="{$QueueLink.ATT}" class="task__button task__button--notice">Add to queue</a>
+                        </div>
+                    </div>
+                <% end_loop %>
+            </div>
+        <% end_if %>
+    </div>
+
+    <div class="task__panel task__panel--immediate">
+        <h2>Non-queueable tasks</h2>
+        <p>These tasks shouldn't be added the queuejobs queue, but you can run them immediately.</p>
+        <% if $ImmediateTasks.Count > 0 %>
+            <div class="task__list">
+                <% loop $ImmediateTasks %>
+                    <div class="task__item">
+                        <div>
+                            <h3>$Title</h3>
+                            <p class="description">$Description</p>
+                        </div>
+                        <div>
+                            <a href="{$TaskLink.ATT}" class="task__button task__button--warning">Run immediately</a>
+                        </div>
+                    </div>
+                <% end_loop %>
+            </div>
+        <% end_if %>
+    </div>
+
+    <div class="task__panel task__panel--queue-only">
+        <h2>Queueable only tasks</h2>
+        <p>These tasks must be be added the queuejobs queue, running it immediately is not allowed.</p>
+        <% if $QueueOnlyTasks.Count > 0 %>
+            <div class="task__list">
+                <% loop $QueueOnlyTasks %>
+                    <div class="task__item">
+                        <div>
+                            <h3>$Title</h3>
+                            <p class="description">$Description</p>
+                        </div>
+                        <div>
+                            <a href="{$QueueLink.ATT}" class="task__button task__button--notice">Add to queue</a>
+                        </div>
+                    </div>
+                <% end_loop %>
+            </div>
+        <% end_if %>
+    </div>
+</div>
+
+$Footer.RAW

--- a/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
+++ b/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
@@ -10,8 +10,10 @@ $Info.RAW
     <input type="radio" id="tab-queue-only-tasks" class="task__selector task__selector--queue-only" name="task__selector" />
 
     <div class="task__panel task__panel--universal">
-        <h2>Queueable tasks</h2>
-        <p>By default these jobs will be added the job queue, rather than run immediately.</p>
+        <div class="task__intro">
+            <h2>Queueable tasks</h2>
+            <p>By default these jobs will be added the job queue, rather than run immediately.</p>
+        </div>
         <% if $UniversalTasks.Count > 0 %>
             <div class="task__list">
                 <% loop $UniversalTasks %>
@@ -31,8 +33,10 @@ $Info.RAW
     </div>
 
     <div class="task__panel task__panel--immediate">
-        <h2>Non-queueable tasks</h2>
-        <p>These tasks shouldn't be added the queuejobs queue, but you can run them immediately.</p>
+        <div class="task__intro">
+            <h2>Non-queueable tasks</h2>
+            <p>These tasks shouldn't be added the queuejobs queue, but you can run them immediately.</p>
+        </div>
         <% if $ImmediateTasks.Count > 0 %>
             <div class="task__list">
                 <% loop $ImmediateTasks %>
@@ -51,8 +55,10 @@ $Info.RAW
     </div>
 
     <div class="task__panel task__panel--queue-only">
-        <h2>Queueable only tasks</h2>
-        <p>These tasks must be be added the queuejobs queue, running it immediately is not allowed.</p>
+        <div class="task__intro">
+            <h2>Queueable only tasks</h2>
+            <p>These tasks must be be added the queuejobs queue, running it immediately is not allowed.</p>
+        </div>
         <% if $QueueOnlyTasks.Count > 0 %>
             <div class="task__list">
                 <% loop $QueueOnlyTasks %>

--- a/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
+++ b/templates/Symbiote/QueuedJobs/Controllers/QueuedTaskRunner.ss
@@ -42,11 +42,11 @@ $Info.RAW
                 <% loop $ImmediateTasks %>
                     <div class="task__item">
                         <div>
-                            <h3>$Title</h3>
-                            <p class="description">$Description</p>
+                            <h3 class="task__title">$Title</h3>
+                            <div class="task__description">$Description</div>
                         </div>
                         <div>
-                            <a href="{$TaskLink.ATT}" class="task__button task__button--warning">Run immediately</a>
+                            <a href="{$TaskLink.ATT}" class="task__button">Run task</a>
                         </div>
                     </div>
                 <% end_loop %>
@@ -60,11 +60,11 @@ $Info.RAW
                 <% loop $QueueOnlyTasks %>
                     <div class="task__item">
                         <div>
-                            <h3>$Title</h3>
-                            <p class="description">$Description</p>
+                            <h3 class="task__title">$Title</h3>
+                            <div class="task__description">$Description</div>
                         </div>
                         <div>
-                            <a href="{$QueueLink.ATT}" class="task__button task__button--notice">Add to queue</a>
+                            <a href="{$QueueLink.ATT}" class="task__button">Queue job</a>
                         </div>
                     </div>
                 <% end_loop %>


### PR DESCRIPTION
# Task runner better UI

Simple UI changes which improve usability of the task runner. Lightweight CSS (no build chain or JS required).

## Problem

* it takes time to find the dev task you want to run especially if you don't know the exact task name
* links which execute dev tasks are tiny, mis-click error can happen
* current UI is cluttered with too many dev tasks and the space is used inefficiently
* rendering component of the task runner is messy (combines backend and frontend logic)
* overriding frontend display requires subclassing

### Current UI
![Screen Shot 2020-06-08 at 12 05 05 PM](https://user-images.githubusercontent.com/26395487/83983311-47e09f80-a981-11ea-9703-c295e92035fa.png)

## Solution

* move the task groups into separate tabs so the screen is less cluttered
* visually separate the dev tasks
* visually separate the action buttons and make them much more visible
* split the rendering into backend (populate data) and a template (render), this allows the template to be overridden without subclassing

### Proposed UI
![Screen Shot 2020-06-08 at 1 16 11 PM](https://user-images.githubusercontent.com/26395487/83984711-8af34080-a98a-11ea-9d00-867e51727de6.png)

## Related issues

https://github.com/symbiote/silverstripe-queuedjobs/issues/302

## Dependencies

https://github.com/silverstripe/silverstripe-framework/pull/9540