### PR TITLE
BUG: Doorman manager child processing fix.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "silverstripe/framework": "^4.7",
         "silverstripe/admin": "^1",
-        "asyncphp/doorman": "^3.0"
+        "asyncphp/doorman": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Services/ProcessManager.php
+++ b/src/Services/ProcessManager.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Services;
+
+use AsyncPHP\Doorman\Manager\ProcessManager as BaseProcessManager;
+
+/**
+ * Class ProcessManager
+ *
+ * customise shell command to allow child tasks to persist even after manager process is terminated
+ * this lets the started jobs to finish properly in case the management process terminates
+ * fore example there are no more jobs to start or queue is paused
+ *
+ * @package Symbiote\QueuedJobs\Services
+ */
+class ProcessManager extends BaseProcessManager
+{
+    /**
+     * @param string $binary
+     * @param string $worker
+     * @param string $stdout
+     * @param string $stderr
+     * @return string
+     */
+    protected function getCommand($binary, $worker, $stdout, $stderr) // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        return sprintf('nohup %s %s %%s %s %s & echo $!', $binary, $worker, $stdout, $stderr);
+    }
+
+    public function __destruct()
+    {
+        // Prevent background tasks from being killed when this script finishes
+        // this is an override for the default behaviour of killing background tasks
+    }
+}

--- a/src/Services/ProcessManager.php
+++ b/src/Services/ProcessManager.php
@@ -24,6 +24,14 @@ class ProcessManager extends BaseProcessManager
      */
     protected function getCommand($binary, $worker, $stdout, $stderr) // phpcs:ignore SlevomatCodingStandard.TypeHints
     {
+        // Nohup is short for “No Hangups.” It’s not a command that you run by itself.
+        // Nohup is a supplemental command that tells the Linux system not to stop another command once it has started.
+        // That means it’ll keep running until it’s done, even if the user that started it logs out
+        // Nohup is used here because the queue management process runs in a loop and it's starting new child processes
+        // which are running jobs
+        // It's possible to have the situation when queue management process terminates as it's no longer needed
+        // to create any new child processes but we still want the existing child processes to continue their work
+        // and finish the jbos which are already running
         return sprintf('nohup %s %s %%s %s %s & echo $!', $binary, $worker, $stdout, $stderr);
     }
 

--- a/src/Tasks/Engines/DoormanRunner.php
+++ b/src/Tasks/Engines/DoormanRunner.php
@@ -2,12 +2,12 @@
 
 namespace Symbiote\QueuedJobs\Tasks\Engines;
 
-use AsyncPHP\Doorman\Manager\ProcessManager;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 use Symbiote\QueuedJobs\Jobs\DoormanQueuedJobTask;
+use Symbiote\QueuedJobs\Services\ProcessManager;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 


### PR DESCRIPTION
# Doorman manager child processing fix

## Problem
Using asynchronous queue runner has a flaw - when the manager process terminates, it also terminates all of its child processes. This is a mistake because there is a valid use case where manager process doesn't have any more work to do (no more jobs to start) but the child processes are still executing jobs.

## Solution
Fix the shell command and prevent the manager process from killing of the child processes.

## Notes

* Requires 3.1.0 version or higher of `asyncphp/doorman`
* split from [Feature batch](https://github.com/symbiote/silverstripe-queuedjobs/pull/290) as `Feature 9 - Job manager process`

## Related issues

https://github.com/symbiote/silverstripe-queuedjobs/issues/306