### PR TITLE
NEW: Advanced jobs admin UI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,17 @@ Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor:
 
 This will add Job data and Messages raw tabs to the job descriptor edit form. Displayed information is read only.
 
+## Enabling extended admin UI
+
+In case your project has many jobs to search through and the basic UI is not enough, you can use the advanced jobs admin UI option.
+This option requires the `silverstripe-terraformers/gridfield-rich-filter-header` module, though.
+To enable the advanced UI simply add this config to your project.
+
+```yaml
+Symbiote\QueuedJobs\Controllers\QueuedJobsAdmin:
+  advanced_admin_ui: true
+```
+
 ## Contributing
 
 ### Translations

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3"
+        "squizlabs/php_codesniffer": "^3",
         "silverstripe-terraformers/gridfield-rich-filter-header": "^2.1"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
     "replace": {
         "silverstripe/queuedjobs": "self.version"
     },
+    "suggest": {
+        "silverstripe-terraformers/gridfield-rich-filter-header": "Required for advanced admin UI"
+    },
     "autoload": {
         "psr-4": {
             "Symbiote\\QueuedJobs\\": "src/",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3"
+        "silverstripe-terraformers/gridfield-rich-filter-header": "^2.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -356,6 +356,20 @@ class QueuedJobDescriptor extends DataObject
     }
 
     /**
+     * @return string
+     */
+    public function getTrimmedImplementation()
+    {
+        $segments = explode('\\', $this->Implementation);
+
+        while (count($segments) > 2) {
+            array_shift($segments);
+        }
+
+        return implode('\\', $segments);
+    }
+
+    /**
      * Return a map of numeric JobType values to localisable string representations.
      * @return array
      */


### PR DESCRIPTION
# Advanced jobs admin UI

Optional advanced UI for jobs admin. Needs to be enabled via configuration API.

## Problem
Finding specific jobs in the Jobs admin is a chore, developers often find themselves scrolling through multiple pages. Finding the right jobs is sometimes impossible as the filter criteria input is quite limited. Using Text fields for input is often tedious.

## Solution
Improved UI. More filters, better input fields, more useful information in the columns.

![job-admin](https://user-images.githubusercontent.com/26395487/84096739-c3f8e700-aa56-11ea-9682-4454d2de61c5.png)

## Notes

* split from [Feature batch](https://github.com/symbiote/silverstripe-queuedjobs/pull/290) as `Feature 1 - Improved Jobs admin UI`

## Related issues
https://github.com/symbiote/silverstripe-queuedjobs/issues/308