### PR TITLE
NEW CLI output in ProcessJobQueueTask

### DIFF
--- a/_config/queuedjobs.yml
+++ b/_config/queuedjobs.yml
@@ -12,6 +12,7 @@ SilverStripe\Core\Injector\Injector:
       queueHandler: %$QueueHandler
       # Change to %$DoormanRunner for async processing (requires *nix)
       queueRunner: %$Symbiote\QueuedJobs\Tasks\Engines\QueueRunner
+      logger: %$Psr\Log\LoggerInterface
 
   DefaultRule:
     class: 'AsyncPHP\Doorman\Rule\InMemoryRule'

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -720,7 +720,7 @@ class QueuedJobService
             });
 
             return true;
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             // note that error here may not be an issue as failing to acquire a job lock is a valid state
             // which happens when other process claimed the job lock first
             $this->getLogger()->debug(
@@ -875,13 +875,8 @@ class QueuedJobService
 
                         try {
                             $job->process();
-                        } catch (Exception $e) {
-                            $logger->error(
-                                $e->getMessage(),
-                                [
-                                    'exception' => $e,
-                                ]
-                            );
+                        } catch (\Throwable $e) {
+                            $logger->error($e->getMessage(), ['exception' => $e]);
                             $jobDescriptor->JobStatus =  QueuedJob::STATUS_BROKEN;
                             $this->extend('updateJobDescriptorAndJobOnException', $jobDescriptor, $job, $e);
                         }
@@ -967,10 +962,6 @@ class QueuedJobService
 
                     $this->extend('updateJobDescriptorAndJobOnCompletion', $jobDescriptor, $job);
                 }
-            } catch (Exception $e) {
-                // PHP 5.6 exception handling
-                $this->handleBrokenJobException($jobDescriptor, $job, $e);
-                $broken = true;
             } catch (\Throwable $e) {
                 // PHP 7 Error handling)
                 $this->handleBrokenJobException($jobDescriptor, $job, $e);

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -476,16 +476,7 @@ class QueuedJobService
         }
 
         $this->getLogger()->error(
-            print_r(
-                [
-                    'errno' => 0,
-                    'errstr' => 'Broken jobs were found in the job queue',
-                    'errfile' => __FILE__,
-                    'errline' => __LINE__,
-                    'errcontext' => [],
-                ],
-                true
-            ),
+            'Broken jobs were found in the job queue',
             [
                 'file' => __FILE__,
                 'line' => __LINE__,
@@ -842,17 +833,8 @@ class QueuedJobService
                     );
                     if (!$jobDescriptor || !$jobDescriptor->exists()) {
                         $broken = true;
-                        $this->getLogger()->error(
-                            print_r(
-                                [
-                                    'errno' => 0,
-                                    'errstr' => 'Job descriptor ' . $jobId . ' could not be found',
-                                    'errfile' => __FILE__,
-                                    'errline' => __LINE__,
-                                    'errcontext' => [],
-                                ],
-                                true
-                            ),
+                        $logger->error(
+                            'Job descriptor ' . $jobId . ' could not be found',
                             [
                                 'file' => __FILE__,
                                 'line' => __LINE__,
@@ -1001,17 +983,8 @@ class QueuedJobService
                         $this->copyJobToDescriptor($job, $jobDescriptor);
                         $jobDescriptor->write();
                     } else {
-                        $this->getLogger()->error(
-                            print_r(
-                                [
-                                    'errno' => 0,
-                                    'errstr' => 'Job descriptor has been set to null',
-                                    'errfile' => __FILE__,
-                                    'errline' => __LINE__,
-                                    'errcontext' => [],
-                                ],
-                                true
-                            ),
+                        $logger->error(
+                            'Job descriptor has been set to null',
                             [
                                 'file' => __FILE__,
                                 'line' => __LINE__,

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -876,18 +876,6 @@ class QueuedJobService
                         try {
                             $job->process();
                         } catch (Exception $e) {
-                            // okay, we'll just catch this exception for now
-                            $job->addMessage(
-                                _t(
-                                    __CLASS__ . '.JOB_EXCEPT',
-                                    'Job caused exception {message} in {file} at line {line}',
-                                    [
-                                        'message' => $e->getMessage(),
-                                        'file' => $e->getFile(),
-                                        'line' => $e->getLine(),
-                                    ]
-                                )
-                            );
                             $logger->error(
                                 $e->getMessage(),
                                 [

--- a/src/Tasks/ProcessJobQueueTask.php
+++ b/src/Tasks/ProcessJobQueueTask.php
@@ -48,7 +48,7 @@ class ProcessJobQueueTask extends BuildTask
         $service = $this->getService();
 
         // Ensure that log messages are visible when executing this task on CLI.
-        // TODO Replace with BuildTask logger: https://github.com/silverstripe/silverstripe-framework/issues/9183
+        // Could be replaced with BuildTask logger: https://github.com/silverstripe/silverstripe-framework/issues/9183
         if (Environment::isCli()) {
             $logger = $service->getLogger();
 

--- a/src/Tasks/ProcessJobQueueTask.php
+++ b/src/Tasks/ProcessJobQueueTask.php
@@ -2,7 +2,11 @@
 
 namespace Symbiote\QueuedJobs\Tasks;
 
+use Monolog\Handler\FilterHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Environment;
 use SilverStripe\Dev\BuildTask;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
@@ -42,6 +46,26 @@ class ProcessJobQueueTask extends BuildTask
         }
 
         $service = $this->getService();
+
+        // Ensure that log messages are visible when executing this task on CLI.
+        // TODO Replace with BuildTask logger: https://github.com/silverstripe/silverstripe-framework/issues/9183
+        if (Environment::isCli()) {
+            $logger = $service->getLogger();
+
+            // Assumes that general purpose logger usually doesn't already contain a stream handler.
+            $errorHandler = new StreamHandler('php://stderr', Logger::ERROR);
+            $standardHandler = new StreamHandler('php://stdout');
+
+            // Avoid double logging of errors
+            $standardFilterHandler = new FilterHandler(
+                $standardHandler,
+                Logger::DEBUG,
+                Logger::WARNING
+            );
+
+            $logger->pushHandler($standardFilterHandler);
+            $logger->pushHandler($errorHandler);
+        }
 
         if ($request->getVar('list')) {
             // List helper


### PR DESCRIPTION
It's counterintuitive to run the queue on CLI (e.g. when testing things),
get zero error output, and then discover why the job was broken by looking
at a tiny text field in the admin/jobs CMS UI.

There's an interesting edge case where the logger *does* output to CLI only
when a broken job is discovered, because that uses the logger for messages
*before* adding the job-specific handlers. And in case a Monolog logger
implementation doesn't have any handlers, it'll add a php://stderr by
default. Very confusing :D

Note that modifying the singleton during execution by adding job-specific
handlers isn't ideal (didn't change that status quo). But there's no clear
interface for any services being executed through a task receiving a logger
*from* the task. So we have to assume they'll use the injector singleton.
Technically it means any messages after the job-specific execution (e.g.
during shutdown) would also be logged into the QueuedJobDescriptor database
record, but you could argue that's desired behaviour.

This should really be fixed by adding BuildTask->getLogger() and making it
available to all tasks, but this is the first step to fix this specific
task behaviour. See
https://github.com/silverstripe/silverstripe-framework/issues/9183