### PR TITLE
NEW: Show job data in descriptor edit form.

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,17 @@ As a consequence, the work might end up being very fragmented and each chunk may
 
 Some projects do not mind this however, so this solution may still be quite suitable.
 
+## Show job data
+
+In case you need an easy access to additonal job data via CMS for debug purposes enable the `show_job_data` option by including the configuration below.
+
+```yaml
+Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor:
+  show_job_data: true
+```
+
+This will add Job data and Messages raw tabs to the job descriptor edit form. Displayed information is read only.
+
 ## Contributing
 
 ### Translations

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\NumericField;
+use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -131,6 +132,14 @@ class QueuedJobDescriptor extends DataObject
      * @var string
      */
     private static $default_sort = 'Created DESC';
+
+    /**
+     * Show job data and raw messages in the edit form
+     *
+     * @config
+     * @var bool
+     */
+    private static $show_job_data = false;
 
     public function requireDefaultRecords()
     {
@@ -318,6 +327,21 @@ class QueuedJobDescriptor extends DataObject
         return isset($map[$this->JobType]) ? $map[$this->JobType] : '(Unknown)';
     }
 
+    /**
+     * @return string|null
+     */
+    public function getSavedJobDataPreview()
+    {
+        return $this->SavedJobData;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMessagesRaw()
+    {
+        return $this->SavedJobMessages;
+    }
 
     /**
      * Return a map of numeric JobType values to localisable string representations.
@@ -505,6 +529,20 @@ class QueuedJobDescriptor extends DataObject
 
         if (strlen($this->SavedJobMessages)) {
             $fields->addFieldToTab('Root.Messages', LiteralField::create('Messages', $this->getMessages()));
+        }
+
+        if ($this->config()->get('show_job_data')) {
+            $fields->addFieldsToTab('Root.JobData', [
+                $jobDataPreview = TextareaField::create('SavedJobDataPreview', 'Job Data'),
+            ]);
+
+            $jobDataPreview->setReadonly(true);
+
+            $fields->addFieldsToTab('Root.MessagesRaw', [
+                $messagesRaw = TextareaField::create('MessagesRaw', 'Messages Raw'),
+            ]);
+
+            $messagesRaw->setReadonly(true);
         }
 
         if (Permission::check('ADMIN')) {


### PR DESCRIPTION
# Show job data in descriptor edit form

Add the option to show read only version of raw job data and raw messages in the job descriptor edit form. Option is disabled by default.

## Problem
Job data is inaccessible in the jobs admin which makes debugging jobs quite difficult. It often requires the developer to download DB snapshot in order to do anything. In case job messages get corrupted (for example in case of getting truncated), they become inaccessible forcing the developer to rely on DB dump instead.

## Solution
Expose job data and raw messages as read only fields in the job edit form.

![Screen Shot 2020-06-11 at 9 17 55 AM](https://user-images.githubusercontent.com/26395487/84319675-81551d00-abc4-11ea-93ac-47f5432918ed.png)

![Screen Shot 2020-06-11 at 9 18 02 AM](https://user-images.githubusercontent.com/26395487/84319693-874afe00-abc4-11ea-8c49-94fe7b503dd5.png)

## Notes

* split from [Feature batch](https://github.com/symbiote/silverstripe-queuedjobs/pull/290) as Feature 2 - Improved Job edit form

## Related issues

https://github.com/symbiote/silverstripe-queuedjobs/issues/313