### PR TITLE
BUG: Queued job service INIT and WAITING state lock release fix.

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -125,6 +125,15 @@ class QueuedJobService
     private static $worker_ttl = 'PT5M';
 
     /**
+     * Timeout value in seconds for the Initialising state
+     * if a job is stuck in this state longer than this value it's considered stalled
+     *
+     * @var int
+     * @config
+     */
+    private static $initialising_state_ttl = 120;
+
+    /**
      * Timestamp (in seconds) when the queue was started
      *
      * @var int
@@ -378,7 +387,7 @@ class QueuedJobService
      *
      * @param string $type Job type
      *
-     * @return QueuedJobDescriptor|false
+     * @return QueuedJobDescriptor|null
      */
     public function getNextPendingJob($type = null)
     {
@@ -440,16 +449,30 @@ class QueuedJobService
                 'JobType' => $queue,
             ]);
 
+        $now = DBDatetime::now();
+
+        /** @var DBDatetime $lastEditedExpiry */
+        $lastEditedExpiry = DBField::create_field(
+            'Datetime',
+            $now->getTimestamp() - $this->config()->get('initialising_state_ttl')
+        );
+
         // If no steps have been processed since the last run, consider it a broken job
         // Only check jobs that have been viewed before. LastProcessedCount defaults to -1 on new jobs.
         // Only check jobs that are past expiry to ensure another process isn't currently executing the job
-        $now = DBDatetime::now()->Rfc2822();
         $stalledJobs = $runningJobs
             ->filter([
                 'LastProcessedCount:GreaterThanOrEqual' => 0,
-                'Expiry:LessThanOrEqual' => $now,
             ])
-            ->where('"StepsProcessed" = "LastProcessedCount"');
+            ->where('"StepsProcessed" = "LastProcessedCount"')
+            ->whereAny([
+                // either job lock is expired
+                '"Expiry" <= ?' => $now->Rfc2822(),
+                // or job lock was never assigned (maybe there were not enough server resources to kick off the process)
+                // fall back to LastEdited time and only restart those jobs that were left untouched for a small while
+                // this covers the situation where a process is still going to pick up the job
+                '"Expiry" IS NULL AND "LastEdited" <= ?' => $lastEditedExpiry->Rfc2822()
+            ]);
 
         /** @var QueuedJobDescriptor $stalledJob */
         foreach ($stalledJobs as $stalledJob) {
@@ -596,8 +619,7 @@ class QueuedJobService
      */
     protected function restartStalledJob($stalledJob)
     {
-        // release job lock on the descriptor so it can run again
-        $stalledJob->Worker = null;
+        $this->releaseJobLock($stalledJob);
 
         if ($stalledJob->ResumeCounts < static::config()->get('stall_threshold')) {
             $stalledJob->restart();
@@ -921,6 +943,7 @@ class QueuedJobService
                             ));
                             if ($jobDescriptor->JobStatus != QueuedJob::STATUS_BROKEN) {
                                 $jobDescriptor->JobStatus = QueuedJob::STATUS_WAIT;
+                                $this->releaseJobLock($jobDescriptor);
                             }
                             $broken = true;
                         }
@@ -933,6 +956,7 @@ class QueuedJobService
                             ));
                             if ($jobDescriptor->JobStatus != QueuedJob::STATUS_BROKEN) {
                                 $jobDescriptor->JobStatus = QueuedJob::STATUS_WAIT;
+                                $this->releaseJobLock($jobDescriptor);
                             }
                             $broken = true;
                         }
@@ -1457,6 +1481,16 @@ class QueuedJobService
                 );
             }
         }
+    }
+
+    /**
+     * Release job lock on the descriptor so it can run again
+     *
+     * @param QueuedJobDescriptor $descriptor
+     */
+    protected function releaseJobLock(QueuedJobDescriptor $descriptor): void
+    {
+        $descriptor->Worker = null;
     }
 
     /**

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -125,13 +125,13 @@ class QueuedJobService
     private static $worker_ttl = 'PT5M';
 
     /**
-     * Timeout value in seconds for the Initialising state
+     * Duration for TTL of initialising state based on ISO 8601 duration specification.
      * if a job is stuck in this state longer than this value it's considered stalled
      *
-     * @var int
+     * @var string
      * @config
      */
-    private static $initialising_state_ttl = 120;
+    private static $initialising_state_ttl = 'PT2M';
 
     /**
      * Timestamp (in seconds) when the queue was started
@@ -434,6 +434,7 @@ class QueuedJobService
      *
      * @param int $queue The queue to check against
      * @return array stalled job and broken job IDs
+     * @throws Exception
      */
     public function checkJobHealth($queue = null)
     {
@@ -449,14 +450,6 @@ class QueuedJobService
                 'JobType' => $queue,
             ]);
 
-        $now = DBDatetime::now();
-
-        /** @var DBDatetime $lastEditedExpiry */
-        $lastEditedExpiry = DBField::create_field(
-            'Datetime',
-            $now->getTimestamp() - $this->config()->get('initialising_state_ttl')
-        );
-
         // If no steps have been processed since the last run, consider it a broken job
         // Only check jobs that have been viewed before. LastProcessedCount defaults to -1 on new jobs.
         // Only check jobs that are past expiry to ensure another process isn't currently executing the job
@@ -467,11 +460,11 @@ class QueuedJobService
             ->where('"StepsProcessed" = "LastProcessedCount"')
             ->whereAny([
                 // either job lock is expired
-                '"Expiry" <= ?' => $now->Rfc2822(),
+                '"Expiry" <= ?' => DBDatetime::now()->Rfc2822(),
                 // or job lock was never assigned (maybe there were not enough server resources to kick off the process)
                 // fall back to LastEdited time and only restart those jobs that were left untouched for a small while
                 // this covers the situation where a process is still going to pick up the job
-                '"Expiry" IS NULL AND "LastEdited" <= ?' => $lastEditedExpiry->Rfc2822()
+                '"Expiry" IS NULL AND "LastEdited" <= ?' => $this->getInitStateExpiry()
             ]);
 
         /** @var QueuedJobDescriptor $stalledJob */
@@ -1430,6 +1423,29 @@ class QueuedJobService
 
         if ($timeToLive) {
             $time->add(new DateInterval($timeToLive));
+        }
+
+        /** @var DBDatetime $expiry */
+        $expiry = DBField::create_field('Datetime', $time->getTimestamp());
+
+        return $expiry->Rfc2822();
+    }
+
+    /**
+     * Get expiry time for a INIT state of a queued job
+     * this helps to identify jobs that have stalled more accurately
+     *
+     * @return string
+     * @throws Exception
+     */
+    protected function getInitStateExpiry(): string
+    {
+        $now = DBDatetime::now()->Rfc2822();
+        $time = new DateTime($now);
+        $timeToLive = $this->config()->get('initialising_state_ttl');
+
+        if ($timeToLive) {
+            $time->sub(new DateInterval($timeToLive));
         }
 
         /** @var DBDatetime $expiry */

--- a/tests/QueuedJobsTest.php
+++ b/tests/QueuedJobsTest.php
@@ -506,17 +506,19 @@ class QueuedJobsTest extends AbstractTest
         // Kick off job processing - this is before job has a worker allocated
         DBDatetime::set_mock_now('2017-01-01 16:00:00');
         $descriptor->JobStatus = QueuedJob::STATUS_INIT;
+        $descriptor->LastProcessedCount = 0;
+        $descriptor->StepsProcessed = 0;
         $descriptor->write();
 
         // Check that valid jobs are left untouched
-        DBDatetime::set_mock_now('2017-01-01 16:00:10');
+        DBDatetime::set_mock_now('2017-01-01 16:01:59');
         $svc->checkJobHealth(QueuedJob::IMMEDIATE);
 
         $descriptor = QueuedJobDescriptor::get()->byID($id);
         $this->assertEquals(QueuedJob::STATUS_INIT, $descriptor->JobStatus);
 
         // Check that init jobs which are considered stuck are handled
-        DBDatetime::set_mock_now('2017-01-01 17:00:00');
+        DBDatetime::set_mock_now('2017-01-01 16:02:00');
         $svc->checkJobHealth(QueuedJob::IMMEDIATE);
 
         $descriptor = QueuedJobDescriptor::get()->byID($id);


### PR DESCRIPTION
# Queued job service INIT and WAITING state lock release fix

This was split from https://github.com/symbiote/silverstripe-queuedjobs/pull/287

## Details

* added a `initialising_state_ttl` setting for `Initialising` to cover an edge case situation, this puts a hard limit on how long a job is allowed to stay in such state (it shouldn't stay in this state for long)
* job lock is released when job processing hits time execution limit or memory limit and goes to waiting state
* minor linting changes

## Failing unit tests

* This is an upstream error, not related to this PR