### PR TITLE
Fix build error from handling broken jobs

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -984,7 +984,7 @@ class QueuedJobService
                 }
             } catch (\Throwable $e) {
                 // PHP 7 Error handling)
-                $this->handleBrokenJobException($jobDescriptor, $job, $e);
+                $this->handleBrokenJobException($jobDescriptor, $e, $job);
                 $broken = true;
             }
 
@@ -1037,10 +1037,10 @@ class QueuedJobService
 
     /**
      * @param QueuedJobDescriptor $jobDescriptor
-     * @param QueuedJob $job
      * @param Exception|\Throwable $e
+     * @param QueuedJob|null $job
      */
-    protected function handleBrokenJobException(QueuedJobDescriptor $jobDescriptor, QueuedJob $job, $e)
+    protected function handleBrokenJobException(QueuedJobDescriptor $jobDescriptor, $e, $job = null)
     {
         // okay, we'll just catch this exception for now
         $this->getLogger()->info(


### PR DESCRIPTION
Fixes #316 where an exception occurs when trying to instantiate the $job object, which means in this handler it expects a QueuedJob but gets null.