### PR TITLE
Require recipe 4.7.x-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ import:
 
 env:
   global:
-    - REQUIRE_RECIPE="4.7.x-dev"
+    - REQUIRE_RECIPE="4.7.x-dev || "

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ version: ~> 1.0
 import:
   - silverstripe/silverstripe-travis-shared:config/provision/standard-jobs-range.yml
 
+env:
+  global:
+    - REQUIRE_RECIPE="4.7.x-dev"


### PR DESCRIPTION
4 branch of queuedjobs requires framework 4.7, so set the minimum recipe to 4.7.x-dev

Squash merge this