### PR TITLE
BUG: Allow zero values for integers and floats within queued job rule.

### DIFF
--- a/src/DataObjects/QueuedJobRule.php
+++ b/src/DataObjects/QueuedJobRule.php
@@ -48,7 +48,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getProcesses()
     {
-        if ($this->getField('Processes')) {
+        if ($this->getField('Processes') !== null) {
             return $this->getField('Processes');
         }
 
@@ -74,7 +74,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getMinimumProcessorUsage()
     {
-        if ($this->getField('MinimumProcessorUsage')) {
+        if ($this->getField('MinimumProcessorUsage') !== null) {
             return $this->getField('MinimumProcessorUsage');
         }
 
@@ -88,7 +88,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getMaximumProcessorUsage()
     {
-        if ($this->getField('MaximumProcessorUsage')) {
+        if ($this->getField('MaximumProcessorUsage') !== null) {
             return $this->getField('MaximumProcessorUsage');
         }
 
@@ -102,7 +102,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getMinimumMemoryUsage()
     {
-        if ($this->getField('MinimumMemoryUsage')) {
+        if ($this->getField('MinimumMemoryUsage') !== null) {
             return $this->getField('MinimumMemoryUsage');
         }
 
@@ -114,7 +114,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getMaximumMemoryUsage()
     {
-        if ($this->getField('MaximumMemoryUsage')) {
+        if ($this->getField('MaximumMemoryUsage') !== null) {
             return $this->getField('MaximumMemoryUsage');
         }
 
@@ -128,7 +128,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getMinimumSiblingProcessorUsage()
     {
-        if ($this->getField('MinimumSiblingProcessorUsage')) {
+        if ($this->getField('MinimumSiblingProcessorUsage') !== null) {
             return $this->getField('MinimumSiblingProcessorUsage');
         }
 
@@ -142,7 +142,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getMaximumSiblingProcessorUsage()
     {
-        if ($this->getField('MaximumSiblingProcessorUsage')) {
+        if ($this->getField('MaximumSiblingProcessorUsage') !== null) {
             return $this->getField('MaximumSiblingProcessorUsage');
         }
 
@@ -156,7 +156,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getMinimumSiblingMemoryUsage()
     {
-        if ($this->getField('MinimumSiblingMemoryUsage')) {
+        if ($this->getField('MinimumSiblingMemoryUsage') !== null) {
             return $this->getField('MinimumSiblingMemoryUsage');
         }
 
@@ -170,7 +170,7 @@ class QueuedJobRule extends DataObject implements Rule
      */
     public function getMaximumSiblingMemoryUsage()
     {
-        if ($this->getField('MaximumSiblingMemoryUsage')) {
+        if ($this->getField('MaximumSiblingMemoryUsage') !== null) {
             return $this->getField('MaximumSiblingMemoryUsage');
         }
 

--- a/tests/QueuedJobRuleTest.php
+++ b/tests/QueuedJobRuleTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Symbiote\QueuedJobs\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use Symbiote\QueuedJobs\DataObjects\QueuedJobRule;
+
+class QueuedJobRuleTest extends SapphireTest
+{
+    /**
+     * @param string $property
+     * @param mixed $value
+     * @param mixed $expected
+     * @dataProvider ruleGetterProvider
+     */
+    public function testQueueRuleGetters($property, $value, $expected)
+    {
+        $rule = QueuedJobRule::create();
+        $rule->{$property} = $value;
+
+        $this->assertSame($expected, $rule->{$property});
+    }
+
+    public function ruleGetterProvider(): array
+    {
+        return [
+            ['Processes', null, 1],
+            ['Processes', 0, 0],
+            ['Processes', 1, 1],
+            ['Processes', 2, 2],
+            ['Handler', null, null],
+            ['Handler', '', null],
+            ['Handler', 'Test', 'Test'],
+            ['MinimumProcessorUsage', null, null],
+            ['MinimumProcessorUsage', 0, 0],
+            ['MinimumProcessorUsage', 1, 1],
+            ['MaximumProcessorUsage', null, null],
+            ['MaximumProcessorUsage', 0, 0],
+            ['MaximumProcessorUsage', 1, 1],
+            ['MinimumMemoryUsage', null, null],
+            ['MinimumMemoryUsage', 0, 0],
+            ['MinimumMemoryUsage', 1, 1],
+            ['MaximumMemoryUsage', null, null],
+            ['MaximumMemoryUsage', 0, 0],
+            ['MaximumMemoryUsage', 1, 1],
+            ['MinimumSiblingProcessorUsage', null, null],
+            ['MinimumSiblingProcessorUsage', 0, 0],
+            ['MinimumSiblingProcessorUsage', 1, 1],
+            ['MaximumSiblingProcessorUsage', null, null],
+            ['MaximumSiblingProcessorUsage', 0, 0],
+            ['MaximumSiblingProcessorUsage', 1, 1],
+            ['MinimumSiblingMemoryUsage', null, null],
+            ['MinimumSiblingMemoryUsage', 0, 0],
+            ['MinimumSiblingMemoryUsage', 1, 1],
+            ['MaximumSiblingMemoryUsage', null, null],
+            ['MaximumSiblingMemoryUsage', 0, 0],
+            ['MaximumSiblingMemoryUsage', 1, 1],
+        ];
+    }
+}


### PR DESCRIPTION
# Allow zero values for integers and floats within queued job rule

Zero values for integers and floats within queued job rule are needed to cover the cases where high memory or processor use should prevent any new jobs from being started. This is currently impossible to set even though it's internally supported within the `AsyncPHP\Doorman\Rules\InMemoryRules::canRunTask`.

This change-set allows zero values to be set for integers and floats.

## Related issues

https://github.com/symbiote/silverstripe-queuedjobs/issues/338