### PR TITLE
fix(QueuedJobDescriptor) Ensure that anything set to 'waiting' has Wo…

### DIFF
--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -252,6 +252,18 @@ class QueuedJobDescriptor extends DataObject
         }
     }
 
+    public function onBeforeWrite()
+    {
+        // if a job is marked as 'waiting' for a restart, we need to reset the
+        // worker it was assigned to, otherwise it'll never pick up and go again if
+        // it was paused from the UI, or a worker stopping to release memory / other reason!
+        if ($this->JobStatus == QueuedJob::STATUS_WAIT) {
+            $this->Worker = null;
+        }
+
+        parent::onBeforeWrite();
+    }
+
     public function onBeforeDelete()
     {
         parent::onBeforeDelete();


### PR DESCRIPTION
…rker reset so it can be picked up by a worker

Currently, jobs that are paused and resumed, or stop running due to queue management reasons, are never picked up and re-started due to the Worker ID it was assigned to not being valid any longer. 