### PR TITLE
only log if theres something to log

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -899,7 +899,9 @@ class QueuedJobService
                     if (!$broken) {
                         // Collect output where jobs aren't using the logger singleton
                         ob_start(function ($buffer, $phase) use ($job, $jobDescriptor) {
-                            $job->addMessage($buffer);
+                            if (!empty($buffer)) {
+                                $job->addMessage($buffer);
+                            }
                             if ($jobDescriptor) {
                                 $this->copyJobToDescriptor($job, $jobDescriptor);
                                 $jobDescriptor->write();


### PR DESCRIPTION
Prevents the spam of empty INFO messages on Jobs as they run