### PR TITLE
PHP version constraint add ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8",
         "silverstripe/framework": "^4.7",
         "silverstripe/admin": "^1",
         "asyncphp/doorman": "^3.1"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8",
+        "php": "^7.1 || ^8.0",
         "silverstripe/framework": "^4.7",
         "silverstripe/admin": "^1",
         "asyncphp/doorman": "^3.1"


### PR DESCRIPTION
PR as requested by @emteknetnz in #358 , adjusting PHP constraint in composer to `^7.1 || ^8.0`.