### PR TITLE
NEW: Default jobs / queue type configuration.

### DIFF
--- a/docs/en/default-jobs.md
+++ b/docs/en/default-jobs.md
@@ -75,7 +75,7 @@ SilverStripe\Core\Injector\Injector:
           # Set the email address to send the alert to if not set site admin email is used OPTIONAL
           email: 'admin@example.com'
           # Make this job specific to only certain queue type (see QueuedJob interface)
-          queue: 1 # This would make this job be picked up only by Immediate queue
+          jobType: 2 # This would make this job be picked up only by the QUEUED queue
         # Minimal implementation will send alerts but not recreate
         AnotherTitle:
           type: 'AJob'

--- a/docs/en/default-jobs.md
+++ b/docs/en/default-jobs.md
@@ -74,6 +74,8 @@ SilverStripe\Core\Injector\Injector:
           recreate: 1
           # Set the email address to send the alert to if not set site admin email is used OPTIONAL
           email: 'admin@example.com'
+          # Make this job specific to only certain queue type (see QueuedJob interface)
+          queue: 1 # This would make this job be picked up only by Immediate queue
         # Minimal implementation will send alerts but not recreate
         AnotherTitle:
           type: 'AJob'

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -564,7 +564,7 @@ class QueuedJobService
                 }
 
                 // Check for specific queue configuration
-                if (array_key_exists('queue', $jobConfig) && (int) $jobConfig['queue'] !== (int) $queue) {
+                if (array_key_exists('jobType', $jobConfig) && (int) $jobConfig['jobType'] !== (int) $queue) {
                     // Default job is specific to a queue type, and it doesn't match - bail out
                     continue;
                 }

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -562,6 +562,13 @@ class QueuedJobService
                     );
                     continue;
                 }
+
+                // Check for specific queue configuration
+                if (array_key_exists('queue', $jobConfig) && (int) $jobConfig['queue'] !== (int) $queue) {
+                    // Default job is specific to a queue type, and it doesn't match - bail out
+                    continue;
+                }
+
                 $job = $activeJobs->filter(array_merge(
                     ['Implementation' => $jobConfig['type']],
                     $jobConfig['filter']

--- a/tests/QueuedJobsTest.php
+++ b/tests/QueuedJobsTest.php
@@ -594,25 +594,27 @@ class QueuedJobsTest extends AbstractTest
         $this->assertEquals(QueuedJob::STATUS_BROKEN, $descriptor->JobStatus);
     }
 
-    public function testCheckdefaultJobs()
+    public function testCheckdefaultJobs(): void
     {
         // Create a job and add it to the queue
         $svc = $this->getService();
-        $testDefaultJobsArray = array(
-            'ArbitraryName' => array(
+        $testDefaultJobsArray = [
+            'ArbitraryName' => [
                 # I'll get restarted and create an alert email
                 'type' => TestQueuedJob::class,
-                'filter' => array(
-                    'JobTitle' => "A Test job"
-                ),
+                'filter' => [
+                    'JobTitle' => "A Test job",
+                ],
                 'recreate' => 1,
-                'construct' => array(
-                    'queue' => QueuedJob::QUEUED
-                ),
+                'construct' => [
+                    'queue' => QueuedJob::QUEUED,
+                ],
                 'startDateFormat' => 'Y-m-d 02:00:00',
                 'startTimeString' => 'tomorrow',
-                'email' => 'test@queuejobtest.com'
-            ));
+                'email' => 'test@queuejobtest.com',
+                'queue' => QueuedJob::QUEUED,
+            ],
+        ];
         $svc->defaultJobs = $testDefaultJobsArray;
         $jobConfig = $testDefaultJobsArray['ArbitraryName'];
 
@@ -627,11 +629,22 @@ class QueuedJobsTest extends AbstractTest
             )
         );
         //assert no jobs currently active
-        $this->assertCount(0, $activeJobs);
+        $this->assertCount(0, $activeJobs, 'We expect no jobs in the queue initially');
+
+        $svc->checkdefaultJobs(QueuedJob::IMMEDIATE);
+        $this->assertCount(
+            0,
+            $activeJobs,
+            'We expect no jobs after running default jobs check for the immediate queue'
+        );
 
         //add a default job to the queue
         $svc->checkdefaultJobs();
-        $this->assertCount(1, $activeJobs);
+        $this->assertCount(
+            1,
+            $activeJobs,
+            'We expect to find a job after running default jobs check for the medium queue'
+        );
         $descriptor = $activeJobs->filter(array_merge(
             array('Implementation' => $jobConfig['type']),
             $jobConfig['filter']

--- a/tests/QueuedJobsTest.php
+++ b/tests/QueuedJobsTest.php
@@ -612,7 +612,7 @@ class QueuedJobsTest extends AbstractTest
                 'startDateFormat' => 'Y-m-d 02:00:00',
                 'startTimeString' => 'tomorrow',
                 'email' => 'test@queuejobtest.com',
-                'queue' => QueuedJob::QUEUED,
+                'jobType' => QueuedJob::QUEUED,
             ],
         ];
         $svc->defaultJobs = $testDefaultJobsArray;


### PR DESCRIPTION
# NEW: Default jobs / queue type configuration.

Added a new configuration option to specify queue type for default jobs. This is handy in case multiple queues are used and you want only one of them to run default jobs.