### PR TITLE
NEW Extend new AbstractGridFieldComponent class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.11",
         "silverstripe/admin": "^1",
         "asyncphp/doorman": "^3.1"
     },

--- a/src/Controllers/QueuedJobsAdmin.php
+++ b/src/Controllers/QueuedJobsAdmin.php
@@ -99,11 +99,11 @@ class QueuedJobsAdmin extends ModelAdmin
         $list = QueuedJobDescriptor::get()->where($filter)->sort('Created', 'DESC');
 
         $gridFieldConfig = GridFieldConfig_RecordEditor::create()
-            ->addComponent(new GridFieldQueuedJobExecute('execute'))
-            ->addComponent(new GridFieldQueuedJobExecute('pause', function ($record) {
+            ->addComponent(GridFieldQueuedJobExecute::create('execute'))
+            ->addComponent(GridFieldQueuedJobExecute::create('pause', function ($record) {
                 return $record->JobStatus == QueuedJob::STATUS_WAIT || $record->JobStatus == QueuedJob::STATUS_RUN;
             }))
-            ->addComponent(new GridFieldQueuedJobExecute('resume', function ($record) {
+            ->addComponent(GridFieldQueuedJobExecute::create('resume', function ($record) {
                 return $record->JobStatus == QueuedJob::STATUS_PAUSED || $record->JobStatus == QueuedJob::STATUS_BROKEN;
             }))
             ->removeComponentsByType([

--- a/src/Forms/GridFieldQueuedJobExecute.php
+++ b/src/Forms/GridFieldQueuedJobExecute.php
@@ -2,6 +2,7 @@
 
 namespace Symbiote\QueuedJobs\Forms;
 
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_ActionProvider;
 use SilverStripe\Forms\GridField\GridField_ColumnProvider;
@@ -10,7 +11,9 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\View\Requirements;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 
-class GridFieldQueuedJobExecute implements GridField_ColumnProvider, GridField_ActionProvider
+class GridFieldQueuedJobExecute extends AbstractGridFieldComponent implements
+    GridField_ColumnProvider,
+    GridField_ActionProvider
 {
     protected $action = 'execute';
 


### PR DESCRIPTION
This makes the `GridFieldQueuedJobExecute` component `Injectable`, and allows any future enhancements in the new abstract class to automatically apply without requiring additional changes in this module.

The class is introduced in silverstripe/framework 4.11.0 (see silverstripe/silverstripe-framework#10204) so the dependency constraint needs to be updated.