### PR TITLE
FIX Ensure DB is active before processing

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -1316,6 +1316,9 @@ class QueuedJobService
      */
     public function processJobQueue($name)
     {
+        if (!DB::is_active()) {
+            return;
+        }
         // Start timer to measure lifetime
         $this->markStarted();
 


### PR DESCRIPTION
When running behat tests on a project with queuedjobs and subsites together, the temporary database will be deleted before the shutdown functions are run.  This fix is to prevent a 'no database selected' error, similar to https://github.com/silverstripe/silverstripe-fulltextsearch/pull/318