### PR TITLE
ENH Add a Type and Status filter to Jobs

### DIFF
--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -132,14 +132,6 @@ class QueuedJobDescriptor extends DataObject
     ];
 
     /**
-     * @var array
-     */
-    private static $field_labels = [
-        'JobStatus' => 'Status',
-        'JobType' => 'Queue Type'
-    ];
-
-    /**
      * @var string
      */
     private static $default_sort = 'Created DESC';
@@ -590,7 +582,7 @@ class QueuedJobDescriptor extends DataObject
         $statuses = $this->getJobStatusValues();
         return DropdownField::create(
             'JobStatus',
-            $this->fieldLabel('JobStatus'),
+            _t(__CLASS__ . '.TABLE_STATUS', 'Status'),
             array_combine($statuses ?? [], $statuses ?? [])
         );
     }
@@ -602,7 +594,7 @@ class QueuedJobDescriptor extends DataObject
     {
         return DropdownField::create(
             'JobType',
-            $this->fieldLabel('JobType'),
+            _t(__CLASS__ . '.JOB_TYPE', 'Job Type'),
             $this->getJobTypeValues()
         );
     }

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -19,6 +19,7 @@ use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\Filters\ExactMatchFilter;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use Symbiote\QueuedJobs\Services\QueuedJob;
@@ -126,6 +127,16 @@ class QueuedJobDescriptor extends DataObject
      */
     private static $searchable_fields = [
         'JobTitle',
+        'JobStatus' => ExactMatchFilter::class,
+        'JobType' => ExactMatchFilter::class
+    ];
+
+    /**
+     * @var array
+     */
+    private static $field_labels = [
+        'JobStatus' => 'Status',
+        'JobType' => 'Queue Type'
     ];
 
     /**
@@ -393,9 +404,7 @@ class QueuedJobDescriptor extends DataObject
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
-        $statuses = $this->getJobStatusValues();
         $runAs = $fields->fieldByName('Root.Main.RunAsID');
-
         $fields->removeByName([
             'Expiry',
             'Implementation',
@@ -432,8 +441,8 @@ class QueuedJobDescriptor extends DataObject
                 )
             ),
             $jobTitle = TextField::create('JobTitle', 'Title'),
-            $status = DropdownField::create('JobStatus', 'Status', array_combine($statuses ?? [], $statuses ?? [])),
-            $jobType = DropdownField::create('JobType', 'Queue type', $this->getJobTypeValues()),
+            $status = $this->buildJobStatusField(),
+            $jobType = $this->buildJobTypeField(),
             $runAs,
             $startAfter = DatetimeField::create('StartAfter', 'Scheduled Start Time'),
             HeaderField::create('JobTimelineTitle', 'Timeline'),
@@ -573,6 +582,31 @@ class QueuedJobDescriptor extends DataObject
         return $fields->makeReadonly();
     }
 
+    /**
+     * Generate a Dropdown field with the list of possible job
+     */
+    private function buildJobStatusField(): DropdownField
+    {
+        $statuses = $this->getJobStatusValues();
+        return DropdownField::create(
+            'JobStatus',
+            $this->fieldLabel('JobStatus'),
+            array_combine($statuses ?? [], $statuses ?? [])
+        );
+    }
+
+    /**
+     * Generate a drop down field with a list of possible job types
+     */
+    private function buildJobTypeField(): DropdownField
+    {
+        return DropdownField::create(
+            'JobType',
+            $this->fieldLabel('JobType'),
+            $this->getJobTypeValues()
+        );
+    }
+
     private function getWorkerExpiry()
     {
         $now = DBDatetime::now();
@@ -584,5 +618,13 @@ class QueuedJobDescriptor extends DataObject
         }
 
         return $time->getTimestamp() - $now->getTimestamp();
+    }
+
+    public function scaffoldSearchFields($_params = null)
+    {
+        $fields = parent::scaffoldSearchFields($_params);
+        $fields->push($this->buildJobStatusField()->setEmptyString(''));
+        $fields->push($this->buildJobTypeField()->setEmptyString(''));
+        return $fields;
     }
 }


### PR DESCRIPTION
By default, you can only filter queued jobs by title, which is kind of stupid.

This adds Type and Status dropdown filters.

![image](https://user-images.githubusercontent.com/1168676/189244831-37ba1878-7837-4724-80db-f1c7827a184f.png)
