### PR TITLE
API Use correct typing for new version of monolog

### DIFF
--- a/src/Services/QueuedJobHandler.php
+++ b/src/Services/QueuedJobHandler.php
@@ -2,8 +2,10 @@
 
 namespace Symbiote\QueuedJobs\Services;
 
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\LogRecord;
 use SilverStripe\Core\Injector\Injectable;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 
@@ -46,16 +48,13 @@ class QueuedJobHandler extends AbstractProcessingHandler
 
     /**
      * Writes the record down to the log of the implementing handler
-     *
-     * @param  array $record
-     * @return void
      */
-    protected function write(array $record)
+    protected function write(LogRecord $record): void
     {
         $this->handleBatch([$record]);
     }
 
-    public function handleBatch(array $records)
+    public function handleBatch(array $records): void
     {
         foreach ($records as $i => $record) {
             $records[$i] = $this->processRecord($records[$i]);
@@ -70,7 +69,7 @@ class QueuedJobHandler extends AbstractProcessingHandler
     /**
      * Ensure that exception context is retained. Similar logic to SyslogHandler.
      */
-    protected function getDefaultFormatter()
+    protected function getDefaultFormatter(): FormatterInterface
     {
         return new LineFormatter('%message% %context% %extra%');
     }

--- a/tests/QueuedJobsTest/QueuedJobsTest_Handler.php
+++ b/tests/QueuedJobsTest/QueuedJobsTest_Handler.php
@@ -3,6 +3,7 @@
 namespace Symbiote\QueuedJobs\Tests\QueuedJobsTest;
 
 use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\LogRecord;
 use SilverStripe\Dev\TestOnly;
 
 /**
@@ -32,8 +33,8 @@ class QueuedJobsTest_Handler extends AbstractProcessingHandler implements TestOn
         $this->messages = array();
     }
 
-    protected function write(array $record)
+    protected function write(LogRecord $record): void
     {
-        $this->messages[] = $record['message'];
+        $this->messages[] = $record->message;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-session-manager/actions/runs/3293535920/jobs/5499427582
> Declaration of Symbiote\QueuedJobs\Services\QueuedJobHandler::write(array $record) must be compatible with Monolog\Handler\AbstractProcessingHandler::write(Monolog\LogRecord $record): void in /home/runner/work/silverstripe-session-manager/silverstripe-session-manager/vendor/symbiote/silverstripe-queuedjobs/src/Services/QueuedJobHandler.php on line 53

and

> Declaration of Symbiote\QueuedJobs\Services\QueuedJobHandler::handleBatch(array $records) must be compatible with Monolog\Handler\Handler::handleBatch(array $records): void in /home/runner/work/silverstripe-queuedjobs/silverstripe-queuedjobs/src/Services/QueuedJobHandler.php on line 56

and 

> Declaration of Symbiote\QueuedJobs\Services\QueuedJobHandler::getDefaultFormatter() must be compatible with Monolog\Handler\AbstractProcessingHandler::getDefaultFormatter(): Monolog\Formatter\FormatterInterface in /var/www/vendor/symbiote/silverstripe-queuedjobs/src/Services/QueuedJobHandler.php on line 71

This is a result of https://github.com/silverstripe/silverstripe-framework/pull/10534

## NOTES
Rerun the broken build from session-manager after merging this PR

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/611