### PR TITLE
(DOCS) Added quotes around value in yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ After: '#queuedjobsettings'
 SilverStripe\Core\Injector\Injector:
   Symbiote\QueuedJobs\Services\QueuedJobService:
     properties:
-      queueRunner: %$DoormanRunner
+      queueRunner: '%$DoormanRunner'
 ```
 
 ## Using Gearman for running jobs


### PR DESCRIPTION
In more recent versions of the framework , the queueRunner value needs to be enclosed in quotes.

Otherwise:

`Fatal error: Uncaught Symfony\Component\Yaml\Exception\ParseException: The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 4 (near "queueRunner: %$DoormanRunner").`