### PR TITLE
FIX grabMutex job lock query on SQLite

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -729,7 +729,8 @@ class QueuedJobService
         try {
             // Start a transaction which will hold until we have a lock on this descriptor.
             DB::get_conn()->withTransaction(function () use ($descriptorId) {
-                $query = 'SELECT "ID" FROM "QueuedJobDescriptor" WHERE "ID" = %s AND "Worker" IS NULL FOR UPDATE';
+                $forUpdate = DB::getConfig()['type'] == 'SQLite3Database' ? '' : ' FOR UPDATE';
+                $query = 'SELECT "ID" FROM "QueuedJobDescriptor" WHERE "ID" = %s AND "Worker" IS NULL' . $forUpdate;
 
                 $row = DB::query(sprintf($query, Convert::raw2sql($descriptorId)))->first();
 


### PR DESCRIPTION
Running a job using an SQLite database causes the update query at `src/Services/QueuedJobService.php:747` to throw an invalid query error. Using the ORM instead of raw database queries prevents this.