### PR TITLE
FIX Use record() instead of first()

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -731,7 +731,7 @@ class QueuedJobService
             DB::get_conn()->withTransaction(function () use ($descriptorId) {
                 $query = 'SELECT "ID" FROM "QueuedJobDescriptor" WHERE "ID" = %s AND "Worker" IS NULL FOR UPDATE';
 
-                $row = DB::query(sprintf($query, Convert::raw2sql($descriptorId)))->first();
+                $row = DB::query(sprintf($query, Convert::raw2sql($descriptorId)))->record();
 
                 if (!is_array($row) || !array_key_exists('ID', $row ?? []) || !$row['ID']) {
                     throw new Exception('Failed to read job lock');


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/642

first() was [removed](https://github.com/silverstripe/silverstripe-framework/commit/53c0147f112a011f8cbdfb964a92dc4eb81a8b7f#diff-9fa698dbb4eb1f1266483fd88cfa70b9950059408af05766f9fb5e8dc0ea52c4L102) in CMS5 - it was just an alias for record()

I can't link to a CI failure specifically, but I get this on my local

`] - Queued Jobs - Failed to acquire job lock Call to undefined method SilverStripe\ORM\Connect\MySQLQuery::first() 2 {"file":"/var/www/vendor/symbiote/silverstripe-queuedjobs/src/Services/QueuedJobService.php","line":777} []`

