### PR TITLE
MNT Ensure parent::__construct() is not passed the wrong param types

### DIFF
--- a/tests/QueuedJobsTest/QueuedJobsTest_Handler.php
+++ b/tests/QueuedJobsTest/QueuedJobsTest_Handler.php
@@ -11,6 +11,17 @@ use SilverStripe\Dev\TestOnly;
  */
 class QueuedJobsTest_Handler extends AbstractProcessingHandler implements TestOnly
 {
+    public function __construct()
+    {
+        // It's important that we call parent::__contruct() here in case we construct
+        // this class passing in the QueuedJobsHandler::__construct() parameters:
+        // (QueuedJob $job, QueuedJobDescriptor $jobDescriptor)
+        // This is because AbstractProcessingHandlers construtor in AbstractHandler::__construct()
+        // has a totally different signature:
+        // (int|string|Level $level = Level::Debug, bool $bubble = true)
+        parent::__construct();
+    }
+
     /**
      * Messages
      *


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/676

The failures in recipe-kitchen-sink only showed up because
a) we added staticpublishqueue to the sink, and it has this yml - https://github.com/silverstripe/silverstripe-staticpublishqueue/blob/6.0/_config/staticpublishqueue.yml#L24 which leads to this being called - https://github.com/silverstripe/silverstripe-staticpublishqueue/blob/6.0/src/Dev/StaticPublisherState.php#L21
b) the latest version of monolog now has strong typing, previously it was loosely typed - https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/AbstractHandler.php#L36