### PR TITLE
FIX Replace assignment with intended comparison

### DIFF
--- a/src/Services/JobErrorHandler.php
+++ b/src/Services/JobErrorHandler.php
@@ -27,7 +27,7 @@ class JobErrorHandler
         if (error_reporting()) {
             // Don't throw E_DEPRECATED in PHP 5.3+
             if (defined('E_DEPRECATED')) {
-                if ($errno == E_DEPRECATED || $errno = E_USER_DEPRECATED) {
+                if (E_DEPRECATED == $errno || E_USER_DEPRECATED == $errno) {
                     return;
                 }
             }


### PR DESCRIPTION
## Expected behaviour

If `E_DEPRECATED` is defined and `$errno` is either `E_DEPRECATED` or `E_USER_DEPRECATED`, return from `handleError()`.

## Actual behaviour

If `E_DEPRECATED` is defined and `$errno` is any value, return from `handleError()`. This means that exceptions are never thrown by the method whenever `E_DEPRECATED` is defined.

