### PR TITLE
NEW Send an email notification when a job is broken

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -19,6 +19,8 @@ en:
     PLURALNAME: 'Queued Job Rules'
     SINGULARNAME: 'Queued Job Rule'
   QueuedJobs:
+    BROKEN_JOBS: 'Broken job(s)'
+    BROKEN_JOBS_MSG: 'The following job(s) appear to be broken.'
     CREATE_JOB_TYPE: 'Create job of type'
     CREATE_NEW_JOB: 'Create new job'
     JOB_EXCEPT: 'Job caused exception %s in %s at line %s'

--- a/src/Services/EmailService.php
+++ b/src/Services/EmailService.php
@@ -6,7 +6,7 @@ use SilverStripe\Control\Director;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\ORM\DataList;
 
 /**
  * Class EmailService
@@ -35,11 +35,6 @@ class EmailService
         );
     }
 
-    /**
-     * @param array $jobConfig
-     * @param string $title
-     * @return Email|null
-     */
     public function createMissingDefaultJobReport(array $jobConfig, string $title): ?Email
     {
         $subject = sprintf('Default Job "%s" missing', $title);
@@ -59,12 +54,6 @@ class EmailService
             ->setHTMLTemplate('QueuedJobsDefaultJob');
     }
 
-    /**
-     * @param string $subject
-     * @param string $message
-     * @param int $jobID
-     * @return Email|null
-     */
     public function createStalledJobReport(string $subject, string $message, int $jobID): ?Email
     {
         $email = $this->createReport($subject);
@@ -81,12 +70,24 @@ class EmailService
             ->setHTMLTemplate('QueuedJobsStalledJob');
     }
 
+    public function createBrokenJobsReport(string $subject, string $message, DataList $jobs): ?Email
+    {
+        $email = $this->createReport($subject);
+        if ($email === null) {
+            return null;
+        }
+        return $email
+            ->setData([
+                'Message' => $message,
+                'Jobs' => $jobs,
+                'Site' => Director::absoluteBaseURL(),
+            ])
+            ->setHTMLTemplate('QueuedJobsBrokenJobs');
+    }
+
     /**
      * Create a generic email report
      * useful for reporting queue service issues
-     *
-     * @param string $subject
-     * @return Email|null
      */
     public function createReport(string $subject): ?Email
     {

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -519,6 +519,15 @@ class QueuedJobService
             ]
         );
 
+        // Send broken job email notification
+        $subject = _t(__CLASS__ . '.BROKEN_JOBS', 'Broken job(s)');
+        $message = _t(__CLASS__ . '.BROKEN_JOBS_MSG', 'The following job(s) appear to be broken.');
+        $email = EmailService::singleton()->createBrokenJobsReport($subject, $message, $brokenJobs);
+        if ($email) {
+            $email->send();
+        }
+
+        // Mark broken jobs as notified
         $placeholders = implode(', ', array_fill(0, count($brokenIDs ?? []), '?'));
         $query = SQLUpdate::create(
             '"QueuedJobDescriptor"',

--- a/templates/QueuedJobsBrokenJobs.ss
+++ b/templates/QueuedJobsBrokenJobs.ss
@@ -1,0 +1,7 @@
+$Message
+
+<% loop $Jobs %>
+- $JobTitle (ID: $ID)
+<% end_loop %>
+
+Log in to $Site to see further details and take any necessary actions.


### PR DESCRIPTION
Issue https://github.com/symbiote/silverstripe-queuedjobs/issues/435

There is an email sent for 'stalled' jobs, however there is not an email sent for 'broken' jobs. There is existing logic to ensure that there is only a single notification sent, however no email is actually sent, instead the only notification goes to the logger. An [inline comment](https://github.com/symbiote/silverstripe-queuedjobs/blob/4/src/Services/QueuedJobService.php#L500) says "email" so looks like the intention all along was to send an email.

Testing steps

Create a vanilla install of silverstripe/installer + this PR

**_config/myemail.yml**
```yml
---
Name: myemail
After:
  - '#project-emailconfig'
---
SilverStripe\Control\Email\Email:
  admin_email:
    admin-email@example.com: 'Admin-email'
# + something to setup mailhog / mailcatcher / etc
```

**MyBrokenJob.php**
```php
<?php

use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
use Symbiote\QueuedJobs\Services\QueuedJob;

class MyBrokenJob extends AbstractQueuedJob
{
    public function getTitle()
    {
        return 'My broken job';
    }

    public function getJobType() {
        return QueuedJob::QUEUED;
    }

    public function process()
    {
        throw new Exception('MY BROKEN JOB EXCEPTION');
    }
}
```

In `admin/queuedjobs` create a new 'My broken job'

In console:
`vendor/bin/sake dev/tasks/ProcessJobQueueTask`
`vendor/bin/sake dev/tasks/CheckJobHealthTask`

There should be an 'Broken job' email that was sent

