### PR TITLE
ENH Don't use deprecated method

### DIFF
--- a/src/Tasks/ProcessJobQueueChildTask.php
+++ b/src/Tasks/ProcessJobQueueChildTask.php
@@ -21,7 +21,7 @@ class ProcessJobQueueChildTask extends BuildTask
     public function __construct()
     {
         parent::__construct();
-        Deprecation::withNoReplacement(function () {
+        Deprecation::withSuppressedNotice(function () {
             Deprecation::notice(
                 '5.3.0',
                 'Will be replaced with Symbiote\QueuedJobs\Cli\ProcessJobQueueChildCommand',


### PR DESCRIPTION
Relies on https://github.com/silverstripe/silverstripe-framework/pull/11390

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11382