### PR TITLE
ENH: CMS edit link for queued job descriptor.

### DIFF
--- a/_config/queuedjobs.yml
+++ b/_config/queuedjobs.yml
@@ -30,6 +30,11 @@ SilverStripe\SiteConfig\SiteConfig:
   extensions:
     - Symbiote\QueuedJobs\Extensions\MaintenanceLockExtension
 
+Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor:
+  cms_edit_owner: Symbiote\QueuedJobs\Controllers\QueuedJobsAdmin
+  extensions:
+    - SilverStripe\Admin\CMSEditLinkExtension
+
 ---
 Name: gearman_queue_settings
 Only:

--- a/src/Controllers/QueuedJobsAdmin.php
+++ b/src/Controllers/QueuedJobsAdmin.php
@@ -47,11 +47,11 @@ class QueuedJobsAdmin extends ModelAdmin
      */
     private static $menu_icon_class = 'font-icon-checklist';
 
-    /**
-     * @var array
-     */
-    private static $managed_models = [
-        QueuedJobDescriptor::class
+    private static array $managed_models = [
+        'jobs' => [
+            'title' => 'Jobs',
+            'dataClass' => QueuedJobDescriptor::class,
+        ]
     ];
 
     /**


### PR DESCRIPTION
# CMS edit link for queued job descriptor

Added the ability for Queued job descriptor to generate its own CMS edit link to support scenarios where this link needs to be generate in the CMS UI after some CMS action created a job.

## Related issues

* https://github.com/silverstripe/silverstripe-queuedjobs/issues/475