### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/admin": "^3",
         "asyncphp/doorman": "^5"
     },

--- a/src/Jobs/DeleteObjectJob.php
+++ b/src/Jobs/DeleteObjectJob.php
@@ -36,7 +36,7 @@ class DeleteObjectJob extends AbstractQueuedJob
      */
     protected function getObject($name = 'Object')
     {
-        return DataObject::get_by_id($this->TargetClass, $this->TargetID);
+        return DataObject::get($this->TargetClass)->setUseCache(true)->byID($this->TargetID);
     }
 
     /**

--- a/src/Jobs/PublishItemsJob.php
+++ b/src/Jobs/PublishItemsJob.php
@@ -31,7 +31,7 @@ class PublishItemsJob extends AbstractQueuedJob implements QueuedJob
 
     protected function getRoot()
     {
-        return DataObject::get_by_id(Page::class, $this->rootID);
+        return Page::get()->setUseCache(true)->byID($this->rootID);
     }
 
     /**
@@ -118,7 +118,7 @@ class PublishItemsJob extends AbstractQueuedJob implements QueuedJob
         $ID = array_shift($remainingChildren);
 
         // get the page
-        $page = DataObject::get_by_id(Page::class, $ID);
+        $page = Page::get()->setUseCache(true)->byID($ID);
         if ($page) {
             // publish it
             $page->publishRecursive();

--- a/src/Jobs/RunBuildTaskJob.php
+++ b/src/Jobs/RunBuildTaskJob.php
@@ -52,7 +52,7 @@ class RunBuildTaskJob extends AbstractQueuedJob
      */
     protected function getObject($name = 'SilverStripe\\Core\\Object')
     {
-        return DataObject::get_by_id($this->TargetClass, $this->TargetID);
+        return DataObject::get($this->TargetClass)->setUseCache(true)->byID($this->TargetID);
     }
 
     /**

--- a/src/Jobs/ScheduledExecutionJob.php
+++ b/src/Jobs/ScheduledExecutionJob.php
@@ -39,7 +39,7 @@ class ScheduledExecutionJob extends AbstractQueuedJob
      */
     public function getDataObject()
     {
-        return DataObject::get_by_id($this->objectType, $this->objectID);
+        return DataObject::get($this->objectType)->setUseCache(true)->byID($this->objectID);
     }
 
     /**

--- a/src/Services/AbstractQueuedJob.php
+++ b/src/Services/AbstractQueuedJob.php
@@ -82,7 +82,7 @@ abstract class AbstractQueuedJob implements QueuedJob, UserContextInterface
         $id = $this->{$name . 'ID'};
         $type = $this->{$name . 'Type'};
         if ($id) {
-            return DataObject::get_by_id($type, $id);
+            return DataObject::get($type)->setUseCache(true)->byID($id);
         }
     }
 

--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -804,10 +804,7 @@ class QueuedJobService
         $logger = $this->getLogger();
 
         // first retrieve the descriptor
-        $jobDescriptor = DataObject::get_by_id(
-            QueuedJobDescriptor::class,
-            (int)$jobId
-        );
+        $jobDescriptor = QueuedJobDescriptor::get()->setUseCache(true)->byID((int)$jobId);
         if (!$jobDescriptor) {
             throw new Exception("$jobId is invalid");
         }
@@ -821,7 +818,7 @@ class QueuedJobService
         // this point of execution in some circumstances
         $originalUserID = isset($_SESSION['loggedInAs']) ? $_SESSION['loggedInAs'] : 0;
         $originalUser = $originalUserID
-            ? DataObject::get_by_id(Member::class, $originalUserID)
+            ? Member::get()->setUseCache(true)->byID($originalUserID)
             : null;
         $runAsUser = null;
 
@@ -871,7 +868,7 @@ class QueuedJobService
                     Subsite::changeSubsite($job->SubsiteID);
 
                     // lets set the base URL as far as Director is concerned so that our URLs are correct
-                    $subsite = DataObject::get_by_id(Subsite::class, $job->SubsiteID);
+                    $subsite = Subsite::get()->setUseCache(true)->byID($job->SubsiteID);
                     if ($subsite && $subsite->exists()) {
                         $domain = $subsite->domain();
                         $base = rtrim(Director::protocol() . $domain, '/') . '/';
@@ -883,10 +880,7 @@ class QueuedJobService
                 // while not finished
                 while (!$job->jobFinished() && !$broken) {
                     // see that we haven't been set to 'paused' or otherwise by another process
-                    $jobDescriptor = DataObject::get_by_id(
-                        QueuedJobDescriptor::class,
-                        (int)$jobId
-                    );
+                    $jobDescriptor = QueuedJobDescriptor::get()->setUseCache(true)->byID((int)$jobId);
                     if (!$jobDescriptor || !$jobDescriptor->exists()) {
                         $broken = true;
                         $logger->error(

--- a/src/Tasks/PublishItemsTask.php
+++ b/src/Tasks/PublishItemsTask.php
@@ -3,9 +3,9 @@
 namespace Symbiote\QueuedJobs\Tasks;
 
 use Exception;
+use Page;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\PolyExecution\PolyOutput;
-use SilverStripe\ORM\DataObject;
 use Symbiote\QueuedJobs\Jobs\PublishItemsJob;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,7 +29,7 @@ class PublishItemsTask extends BuildTask
             $output->writeln('<error>Sorry, you must provide a parent node to publish from</>');
         }
 
-        $item = DataObject::get_by_id('Page', $root);
+        $item = Page::get()->setUseCache(true)->byID($root);
 
         if ($item && $item->exists()) {
             $job = new PublishItemsJob($root);

--- a/tests/QueuedJobsTest.php
+++ b/tests/QueuedJobsTest.php
@@ -184,12 +184,12 @@ class QueuedJobsTest extends SapphireTest
         $job = new TestQueuedJob();
         $id = $svc->queueJob($job);
 
-        $descriptor = DataObject::get_by_id(QueuedJobDescriptor::class, $id);
+        $descriptor = QueuedJobDescriptor::get()->byID($id);
 
         $job = $svc->testInit($descriptor);
         $this->assertInstanceOf(TestQueuedJob::class, $job, 'Job has been triggered');
 
-        $descriptor = DataObject::get_by_id(QueuedJobDescriptor::class, $id);
+        $descriptor = QueuedJobDescriptor::get()->byID($id);
 
         $this->assertEquals(QueuedJob::STATUS_INIT, $descriptor->JobStatus);
     }
@@ -212,7 +212,7 @@ class QueuedJobsTest extends SapphireTest
         $this->assertTrue($result);
 
         // we want to make sure that the current user is the runas user of the job
-        $descriptor = DataObject::get_by_id(QueuedJobDescriptor::class, $id);
+        $descriptor = QueuedJobDescriptor::get()->byID($id);
         $this->assertEquals('Complete', $descriptor->JobStatus);
     }
 

--- a/tests/ScheduledExecutionTest.php
+++ b/tests/ScheduledExecutionTest.php
@@ -62,7 +62,7 @@ class ScheduledExecutionTest extends SapphireTest
         $job->execute();
 
         // reload the test object and make sure its job has now changed
-        $test = DataObject::get_by_id(TestScheduledDataObject::class, $test->ID);
+        $test = TestScheduledDataObject::get()->byID($test->ID);
 
         $this->assertNotEquals($test->ScheduledJobID, $jobId);
         $this->assertEquals('EXECUTED', $test->Message);
@@ -96,7 +96,7 @@ class ScheduledExecutionTest extends SapphireTest
         $job->execute();
 
         // reload the test object and make sure its job has now changed
-        $test = DataObject::get_by_id(TestScheduledDataObject::class, $test->ID);
+        $test = TestScheduledDataObject::get()->byID($test->ID);
 
         $this->assertNotEquals($test->ScheduledJobID, $jobId);
         $this->assertEquals('EXECUTED', $test->Message);
@@ -117,7 +117,7 @@ class ScheduledExecutionTest extends SapphireTest
         $job = $test->ScheduledJob();
         $job->execute();
 
-        $test = DataObject::get_by_id(TestScheduledDataObject::class, $test->ID);
+        $test = TestScheduledDataObject::get()->byID($test->ID);
 
         $job = $test->ScheduledJob();
 


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

Tests have been updated to remove caching where it's not relevant to the test.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
