### PR TITLE
ENH Optimise SQL queries to improve performance

### DIFF
--- a/src/Tasks/PublishItemsTask.php
+++ b/src/Tasks/PublishItemsTask.php
@@ -29,9 +29,9 @@ class PublishItemsTask extends BuildTask
             $output->writeln('<error>Sorry, you must provide a parent node to publish from</>');
         }
 
-        $item = Page::get()->setUseCache(true)->byID($root);
+        $itemExists = Page::get()->setUseCache(true)->filter('ID', $root)->exists();
 
-        if ($item && $item->exists()) {
+        if ($itemExists) {
             $job = new PublishItemsJob($root);
             singleton('Symbiote\\QueuedJobs\\Services\\QueuedJobService')->queueJob($job);
         }


### PR DESCRIPTION
While not reducing the _number_ of queries, I've updated a bunch of calls to `find()` and `byID()` (which were only being used to check if a record exists) to instead use `filter()->exists()` which is more efficient.

## Issue

- https://github.com/silverstripe/.github/issues/416