### PR TITLE
ENH CMS fields cleanup.

### DIFF
--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -425,15 +425,14 @@ class QueuedJobDescriptor extends DataObject
             ]);
 
             // Display override to remove the left margin to address a systemic issue with CompositeField
-            // TODO remove this patch after https://github.com/silverstripe/silverstripe-framework/issues/11857 is fixed
             $cssOverrideContent = <<<'HTML'
-<style>
-.composite,
-.composite > .form__field-holder {
-  margin-left:0 !important;
-}
-</style>
-HTML;
+            <style>
+            .composite,
+            .composite > .form__field-holder {
+              margin-left:0 !important;
+            }
+            </style>
+            HTML;
 
             $progressBarContent = sprintf(
                 '<p>%3$0.2f%% completed</p><p><progress value="%1$d" max="%2$d">%3$0.2f%%</progress></p>',

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -424,14 +424,13 @@ class QueuedJobDescriptor extends DataObject
                 'WorkerCount',
             ]);
 
-//            public const string TYPE_GOOD = 'good'; // green
-//            public const string TYPE_NOTICE = 'notice'; // blue
-//            public const string TYPE_WARNING = 'warning'; //orange
-//            public const string TYPE_ERROR = 'error'; //red
-//            public const string TYPE_PLAIN = ''; // transparent
-//
-//            public const string CATEGORY_MESSAGE = 'message';
-//            public const string CATEGORY_ALERT = 'alert';
+            $progressBarContent = sprintf(
+                '<p>%3$0.2f%% completed</p><p><progress value="%1$d" max="%2$d">%3$0.2f%%</progress></p>',
+                $this->StepsProcessed,
+                $this->TotalSteps,
+                $this->TotalSteps > 0 ? ($this->StepsProcessed / $this->TotalSteps) * 100 : 0
+            );
+
             $timelineHeadingContent = <<<'HTML'
 <p class="alert warning">
 It is recommended to avoid editing these fields as they are managed by the Queue Runner / Service.
@@ -441,15 +440,7 @@ HTML;
             $fields->addFieldsToTab('Root.Main', [
                 CompositeField::create([
                     HeaderField::create('ProgressReportHeading', 'Progress'),
-                    LiteralField::create(
-                        'JobProgressReportIntro',
-                        sprintf(
-                            '<p>%3$0.2f%% completed</p><p><progress value="%1$d" max="%2$d">%3$0.2f%%</progress></p>',
-                            $this->StepsProcessed,
-                            $this->TotalSteps,
-                            $this->TotalSteps > 0 ? ($this->StepsProcessed / $this->TotalSteps) * 100 : 0
-                        )
-                    ),
+                    LiteralField::create('JobProgressReportIntro', $progressBarContent),
                 ]),
                 CompositeField::create([
                     HeaderField::create('OverviewHeading', 'Overview'),
@@ -545,12 +536,21 @@ HTML;
 
             // Advanced
             $fields->addFieldsToTab('Root.Advanced', [
-                HeaderField::create('AdvancedTabTitle', 'Advanced fields', 1),
-                LiteralField::create('AdvancedTabIntro', $advancedFieldsContent),
                 CompositeField::create([
-                    $implementation = TextField::create('Implementation', 'Job Class'),
-                    $signature = TextField::create('Signature', 'Job Signature'),
+                    HeaderField::create('AdvancedTabTitle', 'Advanced fields', 1),
+                    LiteralField::create('AdvancedTabIntro', $advancedFieldsContent),
                     $notifiedBroken = CheckboxField::create('NotifiedBroken', 'Broken job notification sent'),
+                    FieldGroup::create([
+                        $implementation = TextField::create('Implementation', 'Job Class'),
+                        $signature = TextField::create('Signature', 'Job Signature'),
+                    ]),
+                    ToggleCompositeField::create(
+                        'AdvancedTabInfo',
+                        'More details',
+                        [
+                            $advancedTabDetailsField = LiteralField::create('AdvancedTabDetails', ''),
+                        ]
+                    ),
                 ]),
                 CompositeField::create([
                     HeaderField::create('AdvancedTabProgressTitle', 'Progression metadata'),
@@ -634,6 +634,12 @@ HTML;
                 $expiry,
             ]);
             $jobLockDetailsField->setContent($jobLockDetailsContent);
+
+            $advancedTabDetailsContent = $this->createSummaryListFromFields([
+                $implementation,
+                $signature,
+            ]);
+            $advancedTabDetailsField->setContent($advancedTabDetailsContent);
 
             if (strlen($this->SavedJobMessages ?? '')) {
                 $fields->addFieldToTab('Root.Messages', LiteralField::create('Messages', $this->getMessages()));

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -527,7 +527,9 @@ class QueuedJobDescriptor extends DataObject
             ]);
 
             $implementation->setDescription('Class name which is used to execute this job.');
-            $notifiedBroken->setDescription('Indicates if a broken job notification was sent (this happens only once).');
+            $notifiedBroken->setDescription(
+                'Indicates if a broken job notification was sent (this happens only once).'
+            );
             $totalSteps->setDescription('Number of steps which is needed to complete this job.');
             $stepsProcessed->setDescription('Number of steps processed so far.');
             $workerCount->setDescription('Number of workers (processes) used to execute this job overall.');

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -11,12 +11,15 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\DatetimeField;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\ToggleCompositeField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBField;
@@ -421,6 +424,19 @@ class QueuedJobDescriptor extends DataObject
                 'WorkerCount',
             ]);
 
+//            public const string TYPE_GOOD = 'good'; // green
+//            public const string TYPE_NOTICE = 'notice'; // blue
+//            public const string TYPE_WARNING = 'warning'; //orange
+//            public const string TYPE_ERROR = 'error'; //red
+//            public const string TYPE_PLAIN = ''; // transparent
+//
+//            public const string CATEGORY_MESSAGE = 'message';
+//            public const string CATEGORY_ALERT = 'alert';
+            $timelineHeadingContent = <<<'HTML'
+<p class="alert warning">
+It is recommended to avoid editing these fields as they are managed by the Queue Runner / Service.
+</p>
+HTML;
             // Main
             $fields->addFieldsToTab('Root.Main', [
                 CompositeField::create([
@@ -438,24 +454,37 @@ class QueuedJobDescriptor extends DataObject
                 CompositeField::create([
                     HeaderField::create('OverviewHeading', 'Overview'),
                     $jobTitle = TextField::create('JobTitle', 'Title'),
-                    $status = $this->buildJobStatusField(),
-                    $jobType = $this->buildJobTypeField(),
-                    $runAs,
-                    $startAfter = DatetimeField::create('StartAfter', 'Scheduled Start Time'),
+                    FieldGroup::create([
+                        $status = $this->buildJobStatusField(),
+                        $jobType = $this->buildJobTypeField(),
+                    ]),
+                    FieldGroup::create([
+                        $runAs,
+                        $startAfter = DatetimeField::create('StartAfter', 'Scheduled Start Time'),
+                    ]),
+                    ToggleCompositeField::create(
+                        'OverviewInfo',
+                        'More details',
+                        [
+                            $overviewDetailsField = LiteralField::create('OverviewDetails', ''),
+                        ]
+                    )
                 ]),
                 CompositeField::create([
                     HeaderField::create('JobTimelineTitle', 'Timeline'),
-                    LiteralField::create(
-                        'JobTimelineIntro',
-                        sprintf(
-                            '<p>%s</p>',
-                            'It is recommended to avoid editing these fields'
-                            . ' as they are managed by the Queue Runner / Service.'
-                        )
-                    ),
-                    $jobStarted = DatetimeField::create('JobStarted', 'Started (initial)'),
-                    $jobRestarted = DatetimeField::create('JobRestarted', 'Started (recent)'),
-                    $jobFinished = DatetimeField::create('JobFinished', 'Completed'),
+                    LiteralField::create('JobTimelineIntro', $timelineHeadingContent),
+                    FieldGroup::create([
+                        $jobStarted = DatetimeField::create('JobStarted', 'Started (initial)'),
+                        $jobRestarted = DatetimeField::create('JobRestarted', 'Started (recent)'),
+                        $jobFinished = DatetimeField::create('JobFinished', 'Completed'),
+                    ]),
+                    ToggleCompositeField::create(
+                        'JobTimelineInfo',
+                        'More details',
+                        [
+                            $timelineDetailsField = LiteralField::create('JobTimelineDetails', ''),
+                        ]
+                    )
                 ]),
             ]);
 
@@ -483,17 +512,41 @@ class QueuedJobDescriptor extends DataObject
                     . ' have to look like the specified user made them.'
                 );
 
+            $overviewDetailsContent = $this->createSummaryListFromFields([
+                $status,
+                $jobType,
+                $runAs,
+                $startAfter,
+            ]);
+            $overviewDetailsField->setContent($overviewDetailsContent);
+
+            $timelineDetailsContent = $this->createSummaryListFromFields([
+                $jobStarted,
+                $jobRestarted,
+                $jobFinished,
+            ]);
+            $timelineDetailsField->setContent($timelineDetailsContent);
+
+            $advancedFieldsContent = <<<'HTML'
+<p class="alert warning">
+It is recommended to avoid editing these fields as they are managed by the Queue Runner / Service.
+</p>
+HTML;
+            $metadataIntroContent = <<<'HTML'
+<p class="alert notice">
+Job progression mechanism related fields which are used to ensure that stalled jobs are paused / resumed.
+</p>
+HTML;
+            $jobLockIntroContent = <<<'HTML'
+<p class="alert notice">
+Job locking mechanism related fields which are used to ensure that every job gets executed only once at any given time.
+</p>
+HTML;
+
             // Advanced
             $fields->addFieldsToTab('Root.Advanced', [
                 HeaderField::create('AdvancedTabTitle', 'Advanced fields', 1),
-                LiteralField::create(
-                    'AdvancedTabIntro',
-                    sprintf(
-                        '<p>%s</p>',
-                        'It is recommended to avoid editing these fields'
-                        . ' as they are managed by the Queue Runner / Service.'
-                    )
-                ),
+                LiteralField::create('AdvancedTabIntro', $advancedFieldsContent),
                 CompositeField::create([
                     $implementation = TextField::create('Implementation', 'Job Class'),
                     $signature = TextField::create('Signature', 'Job Signature'),
@@ -501,32 +554,36 @@ class QueuedJobDescriptor extends DataObject
                 ]),
                 CompositeField::create([
                     HeaderField::create('AdvancedTabProgressTitle', 'Progression metadata'),
-                    LiteralField::create(
-                        'AdvancedTabProgressIntro',
-                        sprintf(
-                            '<p>%s</p>',
-                            'Job progression mechanism related fields which are used to'
-                            . ' ensure that stalled jobs are paused / resumed.'
-                        )
+                    LiteralField::create('AdvancedTabProgressIntro', $metadataIntroContent),
+                    FieldGroup::create([
+                        $totalSteps = NumericField::create('TotalSteps', 'Steps Total'),
+                        $stepsProcessed = NumericField::create('StepsProcessed', 'Steps Processed'),
+                        $lastProcessCount = NumericField::create('LastProcessedCount', 'Steps Processed (previous)'),
+                        $resumeCount = NumericField::create('ResumeCounts', 'Resume Count'),
+                    ]),
+                    ToggleCompositeField::create(
+                        'AdvancedTabProgressInfo',
+                        'More details',
+                        [
+                            $progressTabDetailsField = LiteralField::create('AdvancedTabProgressDetails', ''),
+                        ]
                     ),
-                    $totalSteps = NumericField::create('TotalSteps', 'Steps Total'),
-                    $stepsProcessed = NumericField::create('StepsProcessed', 'Steps Processed'),
-                    $lastProcessCount = NumericField::create('LastProcessedCount', 'Steps Processed (previous)'),
-                    $resumeCount = NumericField::create('ResumeCounts', 'Resume Count'),
                 ]),
                 CompositeField::create([
                     HeaderField::create('AdvancedTabLockTitle', 'Lock metadata'),
-                    LiteralField::create(
-                        'AdvancedTabLockTitleIntro',
-                        sprintf(
-                            '<p>%s</p>',
-                            'Job locking mechanism related fields which are used to'
-                            . ' ensure that every job gets executed only once at any given time.'
-                        )
+                    LiteralField::create('AdvancedTabLockTitleIntro', $jobLockIntroContent),
+                    FieldGroup::create([
+                        $worker = TextField::create('Worker', 'Worker Signature'),
+                        $workerCount = NumericField::create('WorkerCount', 'Worker Count'),
+                        $expiry = DatetimeField::create('Expiry', 'Lock Expiry'),
+                    ]),
+                    ToggleCompositeField::create(
+                        'AdvancedTabLockInfo',
+                        'More details',
+                        [
+                            $jobLockDetailsField = LiteralField::create('AdvancedTabLockDetails', ''),
+                        ]
                     ),
-                    $worker = TextField::create('Worker', 'Worker Signature'),
-                    $workerCount = NumericField::create('WorkerCount', 'Worker Count'),
-                    $expiry = DatetimeField::create('Expiry', 'Lock Expiry'),
                 ]),
             ]);
 
@@ -547,15 +604,14 @@ class QueuedJobDescriptor extends DataObject
             );
 
             $signature->setDescription(
-                'Usualy derived from the job data, prevents redundant jobs from being created to some degree.'
+                'Usually derived from the job data, prevents redundant jobs from being created to some degree.'
             );
 
-            $resumeCount->setDescription(
-                sprintf(
-                    'Number of times this job stalled and was resumed (limit of %d time(s)).',
-                    QueuedJobService::singleton()->config()->get('stall_threshold')
-                )
+            $resumeCountDescription = sprintf(
+                'Number of times this job stalled and was resumed (limit of %d time(s)).',
+                QueuedJobService::singleton()->config()->get('stall_threshold')
             );
+            $resumeCount->setDescription($resumeCountDescription);
 
             $expiry->setDescription(
                 sprintf(
@@ -563,6 +619,21 @@ class QueuedJobDescriptor extends DataObject
                     $this->getWorkerExpiry()
                 )
             );
+
+            $progressTabDetailsContent = $this->createSummaryListFromFields([
+                $totalSteps,
+                $stepsProcessed,
+                $lastProcessCount,
+                $resumeCount,
+            ]);
+            $progressTabDetailsField->setContent($progressTabDetailsContent);
+
+            $jobLockDetailsContent = $this->createSummaryListFromFields([
+                $worker,
+                $workerCount,
+                $expiry,
+            ]);
+            $jobLockDetailsField->setContent($jobLockDetailsContent);
 
             if (strlen($this->SavedJobMessages ?? '')) {
                 $fields->addFieldToTab('Root.Messages', LiteralField::create('Messages', $this->getMessages()));
@@ -637,5 +708,23 @@ class QueuedJobDescriptor extends DataObject
         $fields->push($this->buildJobStatusField()->setEmptyString(''));
         $fields->push($this->buildJobTypeField()->setEmptyString(''));
         return $fields;
+    }
+
+    /**
+     * Collect field names and descriptions from fields and consolidate them into a summary
+     * This is intended to be used in cases where @see FieldGroup is used which doesn't show field descriptions
+     *
+     * @param array $fields
+     * @return string
+     */
+    private function createSummaryListFromFields(array $fields): string
+    {
+        $items = array_map(function (FormField $field) {
+            return sprintf('<li><b>%s</b> - %s</li>', $field->Title(), $field->getDescription());
+        }, $fields);
+
+        $list = implode(PHP_EOL, $items);
+
+        return sprintf('<ul>%s</ul>', $list);
     }
 }

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -8,6 +8,7 @@ use SilverStripe\Assets\Filesystem;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\DatetimeField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
@@ -389,7 +390,10 @@ class QueuedJobDescriptor extends DataObject
         ];
     }
 
-    public function getCMSFields(): FieldList
+    /**
+     * @return FieldList
+     */
+    public function getCMSFields()
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             $runAs = $fields->fieldByName('Root.Main.RunAsID');
@@ -577,26 +581,16 @@ class QueuedJobDescriptor extends DataObject
 
                 $messagesRaw->setReadonly(true);
             }
-
-            if (Permission::check('ADMIN')) {
-                return;
-            }
-
-            // Readonly CMS view is a lot more useful for debugging than no view at all
-            $readonlyList = $fields->makeReadonly();
-
-            // Remove all existing fields
-            foreach ($fields as $field) {
-                $fields->remove($field);
-            }
-
-            // Add read only fields
-            foreach ($readonlyList as $field) {
-                $fields->add($field);
-            }
         });
 
-        return parent::getCMSFields();
+        $fields = parent::getCMSFields();
+
+        if (Permission::check('ADMIN')) {
+            return $fields;
+        }
+
+        // Readonly CMS view is a lot more useful for debugging than no view at all
+        return $fields->makeReadonly();
     }
 
     /**

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -389,188 +389,212 @@ class QueuedJobDescriptor extends DataObject
         ];
     }
 
-    /**
-     * @return FieldList
-     */
-    public function getCMSFields()
+    public function getCMSFields(): FieldList
     {
-        $fields = parent::getCMSFields();
-        $runAs = $fields->fieldByName('Root.Main.RunAsID');
-        $fields->removeByName([
-            'Expiry',
-            'Implementation',
-            'JobTitle',
-            'JobFinished',
-            'JobRestarted',
-            'JobType',
-            'JobStarted',
-            'JobStatus',
-            'LastProcessedCount',
-            'NotifiedBroken',
-            'ResumeCounts',
-            'RunAs',
-            'RunAsID',
-            'SavedJobData',
-            'SavedJobMessages',
-            'Signature',
-            'StepsProcessed',
-            'StartAfter',
-            'TotalSteps',
-            'Worker',
-            'WorkerCount',
-        ]);
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $runAs = $fields->fieldByName('Root.Main.RunAsID');
+            $fields->removeByName([
+                'Expiry',
+                'Implementation',
+                'JobTitle',
+                'JobFinished',
+                'JobRestarted',
+                'JobType',
+                'JobStarted',
+                'JobStatus',
+                'LastProcessedCount',
+                'NotifiedBroken',
+                'ResumeCounts',
+                'RunAs',
+                'RunAsID',
+                'SavedJobData',
+                'SavedJobMessages',
+                'Signature',
+                'StepsProcessed',
+                'StartAfter',
+                'TotalSteps',
+                'Worker',
+                'WorkerCount',
+            ]);
 
-        // Main
-        $fields->addFieldsToTab('Root.Main', [
-            LiteralField::create(
-                'JobProgressReportIntro',
-                sprintf(
-                    '<p>%3$0.2f%% completed</p><p><progress value="%1$d" max="%2$d">%3$0.2f%%</progress></p>',
-                    $this->StepsProcessed,
-                    $this->TotalSteps,
-                    $this->TotalSteps > 0 ? ($this->StepsProcessed / $this->TotalSteps) * 100 : 0
-                )
-            ),
-            $jobTitle = TextField::create('JobTitle', 'Title'),
-            $status = $this->buildJobStatusField(),
-            $jobType = $this->buildJobTypeField(),
-            $runAs,
-            $startAfter = DatetimeField::create('StartAfter', 'Scheduled Start Time'),
-            HeaderField::create('JobTimelineTitle', 'Timeline'),
-            LiteralField::create(
-                'JobTimelineIntro',
-                sprintf(
-                    '<p>%s</p>',
-                    'It is recommended to avoid editing these fields'
-                    . ' as they are managed by the Queue Runner / Service.'
-                )
-            ),
-            $jobStarted = DatetimeField::create('JobStarted', 'Started (initial)'),
-            $jobRestarted = DatetimeField::create('JobRestarted', 'Started (recent)'),
-            $jobFinished = DatetimeField::create('JobFinished', 'Completed'),
-        ]);
+            // Main
+            $fields->addFieldsToTab('Root.Main', [
+                CompositeField::create([
+                    HeaderField::create('ProgressReportHeading', 'Progress'),
+                    LiteralField::create(
+                        'JobProgressReportIntro',
+                        sprintf(
+                            '<p>%3$0.2f%% completed</p><p><progress value="%1$d" max="%2$d">%3$0.2f%%</progress></p>',
+                            $this->StepsProcessed,
+                            $this->TotalSteps,
+                            $this->TotalSteps > 0 ? ($this->StepsProcessed / $this->TotalSteps) * 100 : 0
+                        )
+                    ),
+                ]),
+                CompositeField::create([
+                    HeaderField::create('OverviewHeading', 'Overview'),
+                    $jobTitle = TextField::create('JobTitle', 'Title'),
+                    $status = $this->buildJobStatusField(),
+                    $jobType = $this->buildJobTypeField(),
+                    $runAs,
+                    $startAfter = DatetimeField::create('StartAfter', 'Scheduled Start Time'),
+                ]),
+                CompositeField::create([
+                    HeaderField::create('JobTimelineTitle', 'Timeline'),
+                    LiteralField::create(
+                        'JobTimelineIntro',
+                        sprintf(
+                            '<p>%s</p>',
+                            'It is recommended to avoid editing these fields'
+                            . ' as they are managed by the Queue Runner / Service.'
+                        )
+                    ),
+                    $jobStarted = DatetimeField::create('JobStarted', 'Started (initial)'),
+                    $jobRestarted = DatetimeField::create('JobRestarted', 'Started (recent)'),
+                    $jobFinished = DatetimeField::create('JobFinished', 'Completed'),
+                ]),
+            ]);
 
-        $jobFinished->setDescription('Job completion time.');
-        $jobRestarted->setDescription('Most recent attempt to run the job.');
-        $jobStarted->setDescription('First attempt to run the job.');
-        $jobType->setDescription('Type of Queue which the jobs belongs to.');
-        $status->setDescription('Represents current state within the job lifecycle.');
+            $jobFinished->setDescription('Job completion time.');
+            $jobRestarted->setDescription('Most recent attempt to run the job.');
+            $jobStarted->setDescription('First attempt to run the job.');
+            $jobType->setDescription('Type of Queue which the jobs belongs to.');
+            $status->setDescription('Represents current state within the job lifecycle.');
 
-        $jobTitle->setDescription(
-            'This field can be used to hold user comments about specific jobs (no functional impact).'
-        );
-
-        $startAfter->setDescription(
-            'Used to prevent the job from starting earlier than the specified time.'
-            . ' Note that this does not guarantee that the job will start'
-            . ' exactly at the specified time (it will start the next time the cron job runs).'
-        );
-
-        $runAs
-            ->setTitle('Run With User')
-            ->setDescription(
-                'Select a user to be used to run this job.'
-                . ' This should be used in case the changes done by this job'
-                . ' have to look like the specified user made them.'
+            $jobTitle->setDescription(
+                'This field can be used to hold user comments about specific jobs (no functional impact).'
             );
 
-        // Advanced
-        $fields->addFieldsToTab('Root.Advanced', [
-            HeaderField::create('AdvancedTabTitle', 'Advanced fields', 1),
-            LiteralField::create(
-                'AdvancedTabIntro',
-                sprintf(
-                    '<p>%s</p>',
-                    'It is recommended to avoid editing these fields'
-                    . ' as they are managed by the Queue Runner / Service.'
-                )
-            ),
-            $implementation = TextField::create('Implementation', 'Job Class'),
-            $signature = TextField::create('Signature', 'Job Signature'),
-            $notifiedBroken = CheckboxField::create('NotifiedBroken', 'Broken job notification sent'),
-            HeaderField::create('AdvancedTabProgressTitle', 'Progression metadata'),
-            LiteralField::create(
-                'AdvancedTabProgressIntro',
-                sprintf(
-                    '<p>%s</p>',
-                    'Job progression mechanism related fields which are used to'
-                    . ' ensure that stalled jobs are paused / resumed.'
-                )
-            ),
-            $totalSteps = NumericField::create('TotalSteps', 'Steps Total'),
-            $stepsProcessed = NumericField::create('StepsProcessed', 'Steps Processed'),
-            $lastProcessCount = NumericField::create('LastProcessedCount', 'Steps Processed (previous)'),
-            $resumeCount = NumericField::create('ResumeCounts', 'Resume Count'),
-            HeaderField::create('AdvancedTabLockTitle', 'Lock metadata'),
-            LiteralField::create(
-                'AdvancedTabLockTitleIntro',
-                sprintf(
-                    '<p>%s</p>',
-                    'Job locking mechanism related fields which are used to'
-                    . ' ensure that every job gets executed only once at any given time.'
-                )
-            ),
-            $worker = TextField::create('Worker', 'Worker Signature'),
-            $workerCount = NumericField::create('WorkerCount', 'Worker Count'),
-            $expiry = DatetimeField::create('Expiry', 'Lock Expiry'),
-        ]);
+            $startAfter->setDescription(
+                'Used to prevent the job from starting earlier than the specified time.'
+                . ' Note that this does not guarantee that the job will start'
+                . ' exactly at the specified time (it will start the next time the cron job runs).'
+            );
 
-        $implementation->setDescription('Class name which is used to execute this job.');
-        $notifiedBroken->setDescription('Indicates if a broken job notification was sent (this happens only once).');
-        $totalSteps->setDescription('Number of steps which is needed to complete this job.');
-        $stepsProcessed->setDescription('Number of steps processed so far.');
-        $workerCount->setDescription('Number of workers (processes) used to execute this job overall.');
-        $worker->setDescription(
-            'Used by a worker (process) to claim this job which prevents any other process from claiming it.'
-        );
+            $runAs
+                ->setTitle('Run With User')
+                ->setDescription(
+                    'Select a user to be used to run this job.'
+                    . ' This should be used in case the changes done by this job'
+                    . ' have to look like the specified user made them.'
+                );
 
-        $lastProcessCount->setDescription(
-            'Steps Processed value from previous execution of this job'
-            . ', used to compare against current state of the steps to determine the difference (progress).'
-        );
-
-        $signature->setDescription(
-            'Usualy derived from the job data, prevents redundant jobs from being created to some degree.'
-        );
-
-        $resumeCount->setDescription(
-            sprintf(
-                'Number of times this job stalled and was resumed (limit of %d time(s)).',
-                QueuedJobService::singleton()->config()->get('stall_threshold')
-            )
-        );
-
-        $expiry->setDescription(
-            sprintf(
-                'Specifies when the lock is released (lock expires %d seconds after the job is claimed).',
-                $this->getWorkerExpiry()
-            )
-        );
-
-        if (strlen($this->SavedJobMessages ?? '')) {
-            $fields->addFieldToTab('Root.Messages', LiteralField::create('Messages', $this->getMessages()));
-        }
-
-        if ($this->config()->get('show_job_data')) {
-            $fields->addFieldsToTab('Root.JobData', [
-                $jobDataPreview = TextareaField::create('SavedJobDataPreview', 'Job Data'),
+            // Advanced
+            $fields->addFieldsToTab('Root.Advanced', [
+                HeaderField::create('AdvancedTabTitle', 'Advanced fields', 1),
+                LiteralField::create(
+                    'AdvancedTabIntro',
+                    sprintf(
+                        '<p>%s</p>',
+                        'It is recommended to avoid editing these fields'
+                        . ' as they are managed by the Queue Runner / Service.'
+                    )
+                ),
+                CompositeField::create([
+                    $implementation = TextField::create('Implementation', 'Job Class'),
+                    $signature = TextField::create('Signature', 'Job Signature'),
+                    $notifiedBroken = CheckboxField::create('NotifiedBroken', 'Broken job notification sent'),
+                ]),
+                CompositeField::create([
+                    HeaderField::create('AdvancedTabProgressTitle', 'Progression metadata'),
+                    LiteralField::create(
+                        'AdvancedTabProgressIntro',
+                        sprintf(
+                            '<p>%s</p>',
+                            'Job progression mechanism related fields which are used to'
+                            . ' ensure that stalled jobs are paused / resumed.'
+                        )
+                    ),
+                    $totalSteps = NumericField::create('TotalSteps', 'Steps Total'),
+                    $stepsProcessed = NumericField::create('StepsProcessed', 'Steps Processed'),
+                    $lastProcessCount = NumericField::create('LastProcessedCount', 'Steps Processed (previous)'),
+                    $resumeCount = NumericField::create('ResumeCounts', 'Resume Count'),
+                ]),
+                CompositeField::create([
+                    HeaderField::create('AdvancedTabLockTitle', 'Lock metadata'),
+                    LiteralField::create(
+                        'AdvancedTabLockTitleIntro',
+                        sprintf(
+                            '<p>%s</p>',
+                            'Job locking mechanism related fields which are used to'
+                            . ' ensure that every job gets executed only once at any given time.'
+                        )
+                    ),
+                    $worker = TextField::create('Worker', 'Worker Signature'),
+                    $workerCount = NumericField::create('WorkerCount', 'Worker Count'),
+                    $expiry = DatetimeField::create('Expiry', 'Lock Expiry'),
+                ]),
             ]);
 
-            $jobDataPreview->setReadonly(true);
+            $implementation->setDescription('Class name which is used to execute this job.');
+            $notifiedBroken->setDescription('Indicates if a broken job notification was sent (this happens only once).');
+            $totalSteps->setDescription('Number of steps which is needed to complete this job.');
+            $stepsProcessed->setDescription('Number of steps processed so far.');
+            $workerCount->setDescription('Number of workers (processes) used to execute this job overall.');
+            $worker->setDescription(
+                'Used by a worker (process) to claim this job which prevents any other process from claiming it.'
+            );
 
-            $fields->addFieldsToTab('Root.MessagesRaw', [
-                $messagesRaw = TextareaField::create('MessagesRaw', 'Messages Raw'),
-            ]);
+            $lastProcessCount->setDescription(
+                'Steps Processed value from previous execution of this job'
+                . ', used to compare against current state of the steps to determine the difference (progress).'
+            );
 
-            $messagesRaw->setReadonly(true);
-        }
+            $signature->setDescription(
+                'Usualy derived from the job data, prevents redundant jobs from being created to some degree.'
+            );
 
-        if (Permission::check('ADMIN')) {
-            return $fields;
-        }
+            $resumeCount->setDescription(
+                sprintf(
+                    'Number of times this job stalled and was resumed (limit of %d time(s)).',
+                    QueuedJobService::singleton()->config()->get('stall_threshold')
+                )
+            );
 
-        // Readonly CMS view is a lot more useful for debugging than no view at all
-        return $fields->makeReadonly();
+            $expiry->setDescription(
+                sprintf(
+                    'Specifies when the lock is released (lock expires %d seconds after the job is claimed).',
+                    $this->getWorkerExpiry()
+                )
+            );
+
+            if (strlen($this->SavedJobMessages ?? '')) {
+                $fields->addFieldToTab('Root.Messages', LiteralField::create('Messages', $this->getMessages()));
+            }
+
+            if ($this->config()->get('show_job_data')) {
+                $fields->addFieldsToTab('Root.JobData', [
+                    $jobDataPreview = TextareaField::create('SavedJobDataPreview', 'Job Data'),
+                ]);
+
+                $jobDataPreview->setReadonly(true);
+
+                $fields->addFieldsToTab('Root.MessagesRaw', [
+                    $messagesRaw = TextareaField::create('MessagesRaw', 'Messages Raw'),
+                ]);
+
+                $messagesRaw->setReadonly(true);
+            }
+
+            if (Permission::check('ADMIN')) {
+                return;
+            }
+
+            // Readonly CMS view is a lot more useful for debugging than no view at all
+            $readonlyList = $fields->makeReadonly();
+
+            // Remove all existing fields
+            foreach ($fields as $field) {
+                $fields->remove($field);
+            }
+
+            // Add read only fields
+            foreach ($readonlyList as $field) {
+                $fields->add($field);
+            }
+        });
+
+        return parent::getCMSFields();
     }
 
     /**

--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -424,6 +424,17 @@ class QueuedJobDescriptor extends DataObject
                 'WorkerCount',
             ]);
 
+            // Display override to remove the left margin to address a systemic issue with CompositeField
+            // TODO remove this patch after https://github.com/silverstripe/silverstripe-framework/issues/11857 is fixed
+            $cssOverrideContent = <<<'HTML'
+<style>
+.composite,
+.composite > .form__field-holder {
+  margin-left:0 !important;
+}
+</style>
+HTML;
+
             $progressBarContent = sprintf(
                 '<p>%3$0.2f%% completed</p><p><progress value="%1$d" max="%2$d">%3$0.2f%%</progress></p>',
                 $this->StepsProcessed,
@@ -477,6 +488,7 @@ HTML;
                         ]
                     )
                 ]),
+                LiteralField::create('CustomCssOverride', $cssOverrideContent),
             ]);
 
             $jobFinished->setDescription('Job completion time.');


### PR DESCRIPTION
# ENH CMS fields cleanup

* `getCMSFields()` wrapped up inside `beforeUpdateCMSFields()` for better customisation
* existing fields grouped logically using `CompositeField` for better CMS UI experience

It's highly recommended to turn off WS when reading the diff.

## Issue

-  https://github.com/silverstripe/silverstripe-queuedjobs/issues/484