### PR TITLE
ENH PHP 8.5 Support

### DIFF
--- a/src/QJUtils.php
+++ b/src/QJUtils.php
@@ -74,8 +74,6 @@ class QJUtils
             $val = 'NULL';
         } elseif (is_int($val)) {
             $val = (int) $val;
-        } elseif (is_double($val)) {
-            $val = (double) $val;
         } elseif (is_float($val)) {
             $val = (float) $val;
         } else {

--- a/tests/QueuedJobsTest.php
+++ b/tests/QueuedJobsTest.php
@@ -723,8 +723,6 @@ class QueuedJobsTest extends SapphireTest
 
         $class = new ReflectionClass(QueuedJobService::class);
         $method = $class->getMethod('grabMutex');
-        $method->setAccessible(true);
-
         // attempt to claim lock on descriptor
         $result = $method->invokeArgs(QueuedJobService::singleton(), [$descriptor]);
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
- Non-canonical cast names (boolean), (integer), (double), and (binary) have been deprecated.
